### PR TITLE
fix(api/gogs): 2 fixes in gogs webhook handling

### DIFF
--- a/src/git/gogs.ts
+++ b/src/git/gogs.ts
@@ -190,11 +190,11 @@ export class GogsApi extends Repo {
 
     public getWebhook(event: string, delivery: string, signature: string, body: any): IWebhook | boolean {
         let secret = process.env.KUBERO_WEBHOOK_SECRET as string;
-        let hash = 'sha256='+crypto.createHmac('sha256', secret).update(JSON.stringify(body, null, '  ')).digest('hex')
+        let hash = crypto.createHmac('sha256', secret).update(JSON.stringify(body, null, '  ')).digest('hex')
 
         let verified = false;
         if (hash === signature) {
-            debug.debug('Gitea webhook signature is valid for event: '+delivery);
+            debug.debug('Gogs webhook signature is valid for event: '+delivery);
             verified = true;
         } else {
             debug.log('ERROR: invalid signature for event: '+delivery);

--- a/src/routes/repo.ts
+++ b/src/routes/repo.ts
@@ -61,7 +61,7 @@ Router.all('/repo/webhooks/:repoprovider', async function (req: Request, res: Re
             //console.log(req.headers)
             let gogs_event = req.headers['x-gogs-event']
             let gogs_delivery = req.headers['x-gogs-delivery']
-            let gogs_signature = req.headers['x-hub-signature-256']
+            let gogs_signature = req.headers['x-gogs-signature']
             let gogs_body = req.body
 
             req.app.locals.kubero.handleWebhook('gogs', gogs_event, gogs_delivery, gogs_signature, gogs_body);


### PR DESCRIPTION
- no sha256= prefix sent by gogs
- wrong header name for signature extraction