### PR TITLE
fix(buildpack/python): do not try to create venv in a readonly environment

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,7 +51,7 @@ buildpacks:
     run:
       repository: python
       tag: 3.10-buster
-      command: "python3 -m venv .venv && . .venv/bin/activate && python3 main.py"
+      command: ". .venv/bin/activate && python3 main.py"
   - name: GoLang
     language: GoLang
     fetch:


### PR DESCRIPTION
- run container was crashlooping because command was attempting to write a file in a readonly volume. Venv creation is not needed because it was already created in the 'build' step