### PR TITLE
Allow configuration of oauth2 scopes

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -49,3 +49,4 @@ KUBERO_CLUSTERISSUER=letsencrypt-prod
 #OAUTH2_CLIENT_ID=
 #OAUTH2_CLIENT_SECRET=
 #OAUTH2_CLIENT_CALLBACKURL=http://kubero.lacolhost.com/api/auth/oauth2/callback
+#OAUTH2_CLIENT_SCOPE=openid profile email groups

--- a/server/.env.test
+++ b/server/.env.test
@@ -44,3 +44,4 @@ DEBUG=*.*
 #OAUTH2_CLIENT_ID=
 #OAUTH2_CLIENT_SECRET=
 #OAUTH2_CLIENT_CALLBACKURL=http://kubero.lacolhost.com/api/auth/oauth2/callback
+#OAUTH2_CLIENT_SCOPE=openid profile email groups

--- a/server/src/modules/auth.ts
+++ b/server/src/modules/auth.ts
@@ -152,12 +152,18 @@ export class Auth {
         }
 
         if (this.authmethods.oauth2) {
+            let scope = [ 'user:email' ];
+            if(process.env.OAUTH2_CLIENT_SCOPE) {
+                scope = process.env.OAUTH2_CLIENT_SCOPE.split(' ');
+            }
+            
             this.passport.use(new OAuth2Strategy({
                 authorizationURL: process.env.OAUTO2_CLIENT_AUTH_URL as string,
                 tokenURL: process.env.OAUTO2_CLIENT_TOKEN_URL as string,
                 clientID: process.env.OAUTH2_CLIENT_ID as string,
                 clientSecret: process.env.OAUTH2_CLIENT_SECRET as string,
-                callbackURL: process.env.OAUTH2_CLIENT_CALLBACKURL as string
+                callbackURL: process.env.OAUTH2_CLIENT_CALLBACKURL as string,
+                scope
             },
             function(accessToken: string, refreshToken: string, profile: any, done: any) {
                 debug.debug( JSON.stringify(profile));

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -59,7 +59,7 @@ Router.get('/auth/github/callback',
 Router.get('/auth/oauth2',
   // #swagger.tags = ['UI']
   // #swagger.summary = 'Authenticate with oauth2'
-  auth.passport.authenticate('oauth2', { scope: [ 'user:email' ] }));
+  auth.passport.authenticate('oauth2'));
 
 Router.get('/auth/oauth2/callback',
   // #swagger.tags = ['UI']


### PR DESCRIPTION
Hi,

first of all: Thank you for the awesome project!

**Background**
I ran into the problem that my oauth2 provider (tested both dex and google) had a problem with the default scope (`user:email`) that kubero requests. 
After looking into the oauth2 implementation I noticed that kubero currently uses a single scope seperated by `:` instead of utilizing the scope array provided by `passport-oauth2`

**Proposed fix**
Allow configuration of the oauth2 scopes via env:
* Added env var `OAUTH2_CLIENT_SCOPE`
* The scope get's split at each space (` `) to allow the user to provide multiple scopes

I tested my proposal using dex, authentik, github and google as the oauth provider.
Happy to receive any feedback!