### PR TITLE
Set all switches to primary color

### DIFF
--- a/client/src/components/apps/addons.vue
+++ b/client/src/components/apps/addons.vue
@@ -142,6 +142,7 @@
                     v-if="field.type === 'switch'"
                     :label="field.label"
                     :required="field.required"
+                    color="primary"
                     dense
                 ></v-switch>
               </v-col>

--- a/client/src/components/apps/form.vue
+++ b/client/src/components/apps/form.vue
@@ -72,6 +72,7 @@
             v-model="ssl"
             label="SSL"
             density="compact"
+            color="primary"
           ></v-switch>
         </v-col>
       </v-row>
@@ -269,6 +270,7 @@
               <v-switch
                 v-model="autodeploy"
                 label="Autodeploy"
+                color="primary"
               ></v-switch>
             </v-col>
           </v-row>
@@ -710,6 +712,7 @@
               <v-switch
                 v-model="autoscale"
                 label="Autoscale"
+                color="primary"
               ></v-switch>
             </v-col>
           </v-row>

--- a/client/src/components/pipelines/form.vue
+++ b/client/src/components/pipelines/form.vue
@@ -47,6 +47,7 @@
           <v-switch
             v-model="gitops"
             label="Connect pipeline to a Git repository (GitOps)"
+            color="primary"
           ></v-switch>
         </v-col>
       </v-row>
@@ -158,6 +159,7 @@
                 :label="phase.name"
                 :disabled="phase.name == 'review' && (repository_status.connected === false || gitops === false)"
                 dense
+                color="primary"
               ></v-switch>
             </v-col>
             <v-col


### PR DESCRIPTION
We noticed that some of the switches in the frontend didn't have the primary color assigned resulting in switched that don't change color when activated.

This PR just sets every switch to primary to improve ui feedback.