### PR TITLE
Load buildPipeline enabled from store

### DIFF
--- a/client/src/components/apps/form.vue
+++ b/client/src/components/apps/form.vue
@@ -1244,7 +1244,6 @@ export default defineComponent({
       imageTag: '',
       deploymentstrategy: "git",
       buildstrategy: "plain",
-      buildPipeline: false,
       pipelineData: {
         domain: '',
         dockerimage: '',
@@ -1447,7 +1446,10 @@ export default defineComponent({
 */
     }},
     computed: {
-      ...mapState(useKuberoStore, ['buildPipeline']),
+      buildPipeline(){
+        const store = useKuberoStore()
+        return store.kubero.buildPipeline
+      }
     },
     mounted() {
       this.loadPipeline();


### PR DESCRIPTION
Hi,

I noticed that the `buildPipeline` var/property on the app settings page wasn't loaded from the right store.
This resulted in the "Dockerfile" and  "Nixpacks" build types never being available in the UI.

I just removed the staticly set var and replaced the `mapState` (which loaded the flag from `buildPipeline` instead of `kubero.buildPipeline`) with a read from the kubero store.
Now the build types get enabled/disabled based on the store setting and a change of the value in the pinia store (achieved using the Vue Devtools Extension in my browser) instantly enables/disables the "Dockerfile" and "Nixpacks" build types.