### PR TITLE
fix: prevent usage of 'new' keyword

### DIFF
--- a/client/src/components/pipelines/form.vue
+++ b/client/src/components/pipelines/form.vue
@@ -332,6 +332,7 @@ export default defineComponent({
         (v: any) => !!v || 'Name is required',
         (v: any) => v.length <= 60 || 'Name must be less than 60 characters',
         (v: any) => /^[a-z0-9][a-z0-9-]*$/.test(v) || 'Allowed characters : [a-z0-9-]',
+        (v: any) => v !== 'new' || 'Name cannot be "new"',
       ],
       domainRules: [
         (v: any) => v.length <= 253 || 'Name must be less than 253 characters',


### PR DESCRIPTION
hi,

When using the name `new` for a pipeline it kinda breaks the app because it's the same route as it would be for creating a new pipeline.

This is a quick fix, other fixes might be: using a random generated string for the slug, using uuid, ....
But I found this to be the one with the least impact