### PR TITLE
feat: add limesurvey template

### DIFF
--- a/services/limesurvey/app.yaml
+++ b/services/limesurvey/app.yaml
@@ -1,0 +1,65 @@
+apiVersion: application.kubero.dev/v1alpha1
+kind: KuberoApp
+metadata:
+    name: limesurvey
+    labels:
+        manager: kubero
+spec:
+    name: limesurvey
+    deploymentstrategy: docker
+    image:
+        repository: adamzammit/limesurvey
+        tag: latest
+        containerPort: "8082"
+    addons: 
+    - displayName: Kubero Mysql
+        env: []
+        icon: /img/addons/MySQL.png
+        id: kubero-operator
+        kind: KuberoMysql
+        resourceDefinitions:
+        KuberoMysql:
+            apiVersion: application.kubero.dev/v1alpha1
+            kind: KuberoMysql
+            metadata:
+            name: limesurvey-mysql
+            spec:
+            mysql:
+                auth:
+                createDatabase: true
+                database: limesurvey
+                password: root
+                rootPassword: root
+                username: root
+                global:
+                storageClass: standard
+                primary:
+                persistence:
+                    accessModes:
+                    - ReadWriteOnce
+                    size: 1Gi
+    envVars: 
+    - name: LIMESURVEY_DB_PASSWORD
+        value: root
+    - name: LIMESURVEY_ADMIN_USER
+        value: root
+    - name: LIME_ADMIN_PASSWORD
+        value: root
+    - LIMESURVEY_ADMIN_NAME:
+        value: Lime Administrator
+    - LIMESURVEY_ADMIN_EMAIL:
+        value: lime@lime.llime
+    extraVolumes: 
+    - accessModes:
+        - ReadWriteMany
+        emptyDir: false
+        mountPath: /var/www/html
+        name: limesurvey-volume
+        size: 1Gi
+        storageClass: standard
+    cronjobs: []
+    extraVolumes: []
+    web:
+        replicaCount: 1
+    worker:
+        replicaCount: 0

--- a/services/limesurvey/service.yaml
+++ b/services/limesurvey/service.yaml
@@ -1,0 +1,9 @@
+name: LimeSurvey
+description: 'LimeSurvey is the simple, quick and anonymous online survey tool that's bursting with juicy insights.'
+tags:
+- survel
+source: https://github.com/LimeSurvey/LimeSurvey
+website: https://www.limesurvey.org
+icon: https://camo.githubusercontent.com/9ae03e7911b79017d9ab4ea626c1c290c8bce1c540e4433414d1263af1ef9b5c/68747470733a2f2f7777772e6c696d657375727665792e6f72672f696d616765732f6c696d657375727665792f7376672f6c6f676f5f6c696d657375727665795f686561642e737667
+documentation: https://manual.limesurvey.org/LimeSurvey_Manual
+screenshots:


### PR DESCRIPTION
Hi @mms-gianni I was able to provision out limesurvey using docker-compose locally. Fixes https://github.com/kubero-dev/kubero/issues/332 & https://github.com/kubero-dev/kubero/issues/325

```
version: '2'

services: 

  limesurvey:
    image: adamzammit/limesurvey:6.5.4
    ports:
      - 127.0.0.1:8082:80
    environment:
      LIMESURVEY_DB_PASSWORD: e/xa|m|ple
      LIMESURVEY_ADMIN_USER: admin
      LIMESURVEY_ADMIN_PASSWORD: password
      LIMESURVEY_ADMIN_NAME: Lime Administrator
      LIMESURVEY_ADMIN_EMAIL: lime@lime.lime
      TZ: Europe/London
    volumes:
      - ./plugins:/var/www/html/plugins
      - ./upload:/var/www/html/upload
      - ./config:/var/www/html/application/config
      - ./sessions:/var/lime/sessions

  mysql:
    image: mariadb:10.5
    environment:
      MYSQL_ROOT_PASSWORD: e/xa|m|ple
    volumes:
       - ./mysql:/var/lib/mysql
```

Based on this information, I have configured the limesurvey. Kindly review my changes. 

Also how do I test these changes, can you share me insights ?

