### PR TITLE
Update form.vue - correct loadRepository invocation

### DIFF
--- a/client/src/components/pipelines/form.vue
+++ b/client/src/components/pipelines/form.vue
@@ -347,6 +347,10 @@ export default defineComponent({
     }),
     computed: {
       showConnectButton() {
+        if(this.gitrepoItemsTab !== this.gitrepo) {
+          setTimeout(()=>this.loadRepository(),0);
+          // trigger the load, but not returning so it will be recomputed when `this.gitrepoItems` assigned.
+        }
         return this.gitrepoItems.includes(this.gitrepo) && this.repository_status.connected === false;
       }
     },
@@ -440,9 +444,16 @@ export default defineComponent({
       },
 
       loadRepository() {
+        if(this.gitrepoItemsTab !== this.repotab) {
+          // this variable do not need to be reactive
+          this.gitrepoItemsTab = this.repotab;
+        }
+        let loadingItem = this.gitrepoItemsTab;
         axios.get(`/api/repo/${this.repotab}/list`)
         .then(response => {
-          this.gitrepoItems = response.data;
+          if(loadingItem === this.gitrepoItemsTab) {
+            this.gitrepoItems = response.data;
+          }
         }).catch(error => {
           console.log(error);
         });


### PR DESCRIPTION
# Description

If the provider list has only one provider which is not github, @change event never occurs so `loadRepository` wont be called with the right provider, which make `showConnectButton` always return false. This fix make `loadRepository` to be a computation dependency of `showConnectButton` so it can have the right value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pure simple modification, I havent tested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [_] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules