### PR TITLE
fix: catch startup error when prometheus is not accessible/configureswq

### DIFF
--- a/server/src/configure.ts
+++ b/server/src/configure.ts
@@ -35,7 +35,9 @@ const { KUBERO_SESSION_KEY = crypto.randomBytes(20).toString('hex') } = process.
 
 export const configure = async (app: Express, server: Server) => {
     // Load Version from File
-    process.env.npm_package_version = fs.readFileSync('./VERSION','utf8');;
+    process.env.npm_package_version = fs.readFileSync('./VERSION','utf8');
+
+    console.log("Kubero Version: " + process.env.npm_package_version);
 
     app.use(cors())
     app.use(cookieParser())

--- a/server/src/modules/metrics.ts
+++ b/server/src/modules/metrics.ts
@@ -64,11 +64,16 @@ export class Metrics {
     }
 
     public async getStatus(): Promise<boolean> {
-        const status = await this.prom.status();
-        if (status === undefined || status === null || status === false) {
+        try {
+            const status = await this.prom.status();
+            
+            if (status === undefined || status === null || status === false) {
+                return false;
+            } else {
+                return true;
+            }
+        } catch (error) {
             return false;
-        } else {
-            return true;
         }
     }
 


### PR DESCRIPTION
Fixes startup error. 

THX @sillen102 for raising this bug.