### PR TITLE
remove storage classes in templates to avoid errors

### DIFF
--- a/services/activepieces/app.yaml
+++ b/services/activepieces/app.yaml
@@ -67,7 +67,7 @@ spec:
                                       password: activepieces
                                       postgresPassword: admin
                                       username: activepieces
-                              storageClass: standard
+                              storageClass:
                           primary:
                               persistence:
                                   size: 1Gi
@@ -90,7 +90,7 @@ spec:
                           global:
                               redis:
                                   password: activepieces
-                              storageClass: standard
+                              storageClass:
                           master:
                               persistence:
                                   size: 1Gi

--- a/services/affine/app.yaml
+++ b/services/affine/app.yaml
@@ -32,7 +32,7 @@ spec:
           mountPath: /root/.affine
           name: affine-volume
           size: 1Gi
-          storageClass: standard
+          storageClass:
     cronjobs: []
     addons:
         - displayName: Postgresql
@@ -55,7 +55,7 @@ spec:
                                       password: afffine
                                       postgresPassword: postgres
                                       username: affine
-                              storageClass: standard
+                              storageClass:
                           primary:
                               persistence:
                                   size: 1Gi
@@ -78,7 +78,7 @@ spec:
                           global:
                               redis:
                                   password: affine
-                              storageClass: standard
+                              storageClass:
                           master:
                               persistence:
                                   size: 1Gi

--- a/services/appsmith/app.yaml
+++ b/services/appsmith/app.yaml
@@ -22,7 +22,7 @@ spec:
     mountPath: /appsmith-stacks
     name: appsmith-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/authorizer/app.yaml
+++ b/services/authorizer/app.yaml
@@ -25,7 +25,7 @@ spec:
     mountPath: /database
     name: authorizer-data-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/bitwarden/app.yaml
+++ b/services/bitwarden/app.yaml
@@ -32,7 +32,7 @@ spec:
           mountPath: /etc/bitwarden
           name: bitwarden
           size: 1Gi
-          storageClass: standard
+          storageClass:
     cronjobs: []
     addons:
         - displayName: Postgresql
@@ -55,7 +55,7 @@ spec:
                                       password: bitwarden
                                       postgresPassword: bitwarden
                                       username: bitwarden
-                              storageClass: standard
+                              storageClass:
                           primary:
                               persistence:
                                   size: 1Gi

--- a/services/calcom/app.yaml
+++ b/services/calcom/app.yaml
@@ -33,7 +33,7 @@ spec:
                   password: calcom
                   postgresPassword: calcom
                   username: calcom
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 size: 1Gi

--- a/services/casdoor/app.yaml
+++ b/services/casdoor/app.yaml
@@ -30,7 +30,7 @@ spec:
               rootPassword: casdoor
               username: casdoor
             global:
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 accessModes:

--- a/services/changedetection/app.yaml
+++ b/services/changedetection/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /datastore
     name: changedetection-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/chartmuseum/app.yaml
+++ b/services/chartmuseum/app.yaml
@@ -23,7 +23,7 @@ spec:
     mountPath: /charts
     name: chartmuseum-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/coral/app.yaml
+++ b/services/coral/app.yaml
@@ -27,7 +27,7 @@ spec:
             global:
               redis:
                 password: changeme
-              storageClass: standard
+              storageClass:
             master:
               persistence:
                 size: 1Gi
@@ -61,7 +61,7 @@ spec:
             directoryPerDB: false
             disableJavascript: false
             global:
-              storageClass: standard
+              storageClass:
             persistence:
               size: 1Gi
             replicaCount: 1

--- a/services/databag/app.yaml
+++ b/services/databag/app.yaml
@@ -18,7 +18,7 @@ spec:
           mountPath: /var/lib/databag
           name: databag-data
           size: 1Gi
-          storageClass: standard
+          storageClass:
     cronjobs: []
     addons: []
     web:

--- a/services/etherpad/app.yaml
+++ b/services/etherpad/app.yaml
@@ -33,7 +33,7 @@ spec:
                   password: etherpad
                   postgresPassword: etherpad
                   username: etherpad
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 size: 1Gi

--- a/services/ghost/app.yaml
+++ b/services/ghost/app.yaml
@@ -30,7 +30,7 @@ spec:
               rootPassword: ghost
               username: ghost
             global:
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 accessModes:
@@ -57,7 +57,7 @@ spec:
     mountPath: /var/lib/ghost/content
     name: ghost-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/gotify/app.yaml
+++ b/services/gotify/app.yaml
@@ -27,7 +27,7 @@ spec:
     mountPath: /app/data
     name: gotify-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/grafana/app.yaml
+++ b/services/grafana/app.yaml
@@ -21,7 +21,7 @@ spec:
     mountPath: /var/lib/grafana
     name: grafana-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/homarr/app.yaml
+++ b/services/homarr/app.yaml
@@ -19,14 +19,14 @@ spec:
     mountPath: /app/data/configs
     name: homar-config
     size: 10Mi
-    storageClass: standard
+    storageClass:
   - accessModes:
     - ReadWriteMany
     emptyDir: false
     mountPath: /app/public/icons
     name: homarr-icons
     size: 200Mi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/homebox/app.yaml
+++ b/services/homebox/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /data
     name: homebox-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/homer/app.yaml
+++ b/services/homer/app.yaml
@@ -25,7 +25,7 @@ spec:
     mountPath: /www/assets
     name: homer-data
     size: 300Mi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/joomla/app.yaml
+++ b/services/joomla/app.yaml
@@ -30,7 +30,7 @@ spec:
                   password: joomla
                   postgresPassword: joomla
                   username: joomla
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 size: 1Gi
@@ -47,14 +47,14 @@ spec:
     mountPath: /var/www/html
     name: joomla-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   - accessModes:
     - ReadWriteMany
     emptyDir: false
     mountPath: /var/run/apache2
     name: joomla-rundir
     size: 1Mi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/keila/app.yaml
+++ b/services/keila/app.yaml
@@ -47,7 +47,7 @@ spec:
                                       password: keila
                                       postgresPassword: keila
                                       username: keila
-                              storageClass: standard
+                              storageClass:
                           primary:
                               persistence:
                                   size: 1Gi

--- a/services/kuma/app.yaml
+++ b/services/kuma/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /app/data
     name: kuma-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/limesurvey/app.yaml
+++ b/services/limesurvey/app.yaml
@@ -32,7 +32,7 @@ spec:
                   rootPassword: root
                   username: root
                   global:
-                  storageClass: standard
+                  storageClass:
                   primary:
                   persistence:
                       accessModes:
@@ -56,7 +56,7 @@ spec:
           mountPath: /var/www/html
           name: limesurvey-volume
           size: 1Gi
-          storageClass: standard
+          storageClass:
     cronjobs: []
     web:
         replicaCount: 1

--- a/services/meilisearch/app.yaml
+++ b/services/meilisearch/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /meili_data
     name: meilidata-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/memos/app.yaml
+++ b/services/memos/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /var/opt/memos
     name: memos-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/mosparo/app.yaml
+++ b/services/mosparo/app.yaml
@@ -51,7 +51,7 @@ spec:
     mountPath: /mosparo-data
     name: mosparo-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/nocodb/app.yaml
+++ b/services/nocodb/app.yaml
@@ -22,7 +22,7 @@ spec:
     mountPath: /usr/app/data/
     name: nocodb-data-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/ntfy/app.yaml
+++ b/services/ntfy/app.yaml
@@ -22,7 +22,7 @@ spec:
       mountPath: /var/cache/ntfy
       name: ntfy-cache-volume
       size: 500Mi
-      storageClass: standard
+      storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/opengist/app.yaml
+++ b/services/opengist/app.yaml
@@ -18,7 +18,7 @@ spec:
     mountPath: /root/.opengist
     name: opengist-volume
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/passbolt/app.yaml
+++ b/services/passbolt/app.yaml
@@ -30,7 +30,7 @@ spec:
               rootPassword: changeme
               username: passbolt
             global:
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 accessModes:

--- a/services/planka/app.yaml
+++ b/services/planka/app.yaml
@@ -30,7 +30,7 @@ spec:
           mountPath: /app/public/user-avatars
           name: planka-user-avatars
           size: 0.1Gi
-          storageClass: standard
+          storageClass:
         - accessMode: ReadWriteOnce
           accessModes:
               - ReadWriteOnce
@@ -38,7 +38,7 @@ spec:
           mountPath: /app/public/project-background-images
           name: planka-project-background-images
           size: 0.5Gi
-          storageClass: standard
+          storageClass:
         - accessMode: ReadWriteOnce
           accessModes:
               - ReadWriteOnce
@@ -46,7 +46,7 @@ spec:
           mountPath: /app/private/attachments
           name: planka-attachments
           size: 1Gi
-          storageClass: standard
+          storageClass:
     cronjobs: []
     addons:
         - displayName: Postgresql
@@ -69,7 +69,7 @@ spec:
                                       password: postgresql
                                       postgresPassword: postgresql
                                       username: planka
-                              storageClass: standard
+                              storageClass:
                           primary:
                               persistence:
                                   size: 1Gi

--- a/services/rocketchat/app.yaml
+++ b/services/rocketchat/app.yaml
@@ -36,7 +36,7 @@ spec:
             directoryPerDB: false
             disableJavascript: false
             global:
-              storageClass: standard
+              storageClass:
             persistence:
               size: 1Gi
             replicaCount: 1

--- a/services/ryot/app.yaml
+++ b/services/ryot/app.yaml
@@ -35,7 +35,7 @@ spec:
                                       password: ryot
                                       postgresPassword: postgres
                                       username: ryot
-                              storageClass: standard
+                              storageClass:
                           primary:
                               persistence:
                                   size: 1Gi

--- a/services/serge/app.yaml
+++ b/services/serge/app.yaml
@@ -19,14 +19,14 @@ spec:
     mountPath: /usr/src/app/weights
     name: weights
     size: 70Gi
-    storageClass: standard
+    storageClass:
   - accessModes:
     - ReadWriteOnce
     emptyDir: false
     mountPath: /data/db
     name: datadb
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/slink/app.yaml
+++ b/services/slink/app.yaml
@@ -28,7 +28,7 @@ spec:
           mountPath: /var/data
           name: slink-volume
           size: 10Gi
-          storageClass: standard
+          storageClass:
     cronjobs: []
     addons: []
     web:

--- a/services/timetagger/app.yaml
+++ b/services/timetagger/app.yaml
@@ -25,7 +25,7 @@ spec:
     mountPath: /data/_timetagger
     name: timetagger-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/trilium/app.yaml
+++ b/services/trilium/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /home/node/trilium-data
     name: trilium-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/vaultwarden/app.yaml
+++ b/services/vaultwarden/app.yaml
@@ -19,7 +19,7 @@ spec:
     mountPath: /data
     name: vaultwarden-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/whoogle/app.yaml
+++ b/services/whoogle/app.yaml
@@ -19,14 +19,14 @@ spec:
     mountPath: /var/lib
     name: whoogle-tor
     size: 1Gi
-    storageClass: standard
+    storageClass:
   - accessModes:
     - ReadWriteMany
     emptyDir: false
     mountPath: /whoogle/app/static/build
     name: whoogle-build
     size: 20Mi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/wikijs/app.yaml
+++ b/services/wikijs/app.yaml
@@ -23,7 +23,7 @@ spec:
     mountPath: /wiki/data
     name: wikijs-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:

--- a/services/wordpress/app.yaml
+++ b/services/wordpress/app.yaml
@@ -30,7 +30,7 @@ spec:
               rootPassword: wordpress
               username: wordpress
             global:
-              storageClass: standard
+              storageClass:
             primary:
               persistence:
                 accessModes:
@@ -53,7 +53,7 @@ spec:
     mountPath: /bitnami/wordpress
     name: wordpress-data
     size: 1Gi
-    storageClass: standard
+    storageClass:
   web:
     replicaCount: 1
   worker:


### PR DESCRIPTION
# Description

Having "standard" storageclass in the templates might fail on some Providers, when no "standard" is available. 

Better to have them empty, and avoid submitting a faulty template. 

## Type of change

> Please delete options that are not relevant.

- [ ] Template (non-breaking change which adds a template)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I've built the image and tested it on a kubernetes cluster

**Test Configuration**:

- Operator Version: N/A
- Kubernetes Version: N/A
- Kubero CLI Version (if applicable): N/A

# Checklist:

- [ ] I removed unnecessary debug logs
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works
<!-- - [ ] New and existing unit tests pass locally with my changes
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->