### PR TITLE
docs: fix broken link to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Basically *everything* that can be packaged in a single container can be deploye
 Kubero starts now building your app. Once the build is complete, Kubero will launch the final container and make it accessible via the configured domain. 
 
 ## Documentation
-https://www.kubero.dev/docs/quickstart
+https://www.kubero.dev/docs/
 
 ## Roadmap
 https://github.com/orgs/kubero-dev/projects/1/views/3


### PR DESCRIPTION
# Description

The PR fixes the broken link to documentation.

I just discovered this project, I went through README, clicked "Documentation" at the end of it, and all I got was "Page Not Found". This doesn't give a good impression.

## Type of change

> Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I clicked the new link and it worked.

# Checklist:

- [x] I removed unnecessary debug logs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
