### PR TITLE
fix: deploy: invalid character 's' looking for beginning of object key string

### DIFF
--- a/server/src/deployments/templates/buildpacks.yaml.ts
+++ b/server/src/deployments/templates/buildpacks.yaml.ts
@@ -40,11 +40,12 @@ spec:
             value: "123456"
           - name: APP
             value: example
+          - name: PATCH_JSON
+            value: '{"spec":{"image":{"repository":"$REPOSITORY","tag": "$TAG"}}}'
           command:
           - sh
           - -c
-          - 'kubectl patch kuberoapps $APP --type=merge -p "{\"spec\":{\"image\":{\"repository\":
-            \"$REPOSITORY\",\"tag\": \"$TAG\"}}}"'
+          - 'kubectl patch kuberoapps $APP --type=merge -p "$PATCH_JSON"'
           image: bitnami/kubectl:latest
           imagePullPolicy: Always
           resources: {}

--- a/server/src/deployments/templates/dockerfile.yaml.ts
+++ b/server/src/deployments/templates/dockerfile.yaml.ts
@@ -41,11 +41,12 @@ spec:
             value: 123456
           - name: APP
             value: example
+          - name: PATCH_JSON
+            value: '{"spec":{"image":{"repository":"$REPOSITORY","tag": "$TAG"}}}'
           command:
           - sh
           - -c
-          - 'kubectl patch kuberoapps $APP --type=merge -p "{\"spec\":{\"image\":{\"repository\":
-            \"$REPOSITORY\",\"tag\": \"$TAG\"}}}"'
+          - 'kubectl patch kuberoapps $APP --type=merge -p "$PATCH_JSON"'
           image: bitnami/kubectl:latest
           imagePullPolicy: Always
           name: deploy

--- a/server/src/deployments/templates/nixpacks.yaml.ts
+++ b/server/src/deployments/templates/nixpacks.yaml.ts
@@ -41,11 +41,12 @@ spec:
             value: 123456
           - name: APP
             value: example
+          - name: PATCH_JSON
+            value: '{"spec":{"image":{"repository":"$REPOSITORY","tag": "$TAG"}}}'
           command:
           - sh
           - -c
-          - 'kubectl patch kuberoapps $APP --type=merge -p "{\"spec\":{\"image\":{\"repository\":
-            \"$REPOSITORY\",\"tag\": \"$TAG\"}}}"'
+          - 'kubectl patch kuberoapps $APP --type=merge -p "$PATCH_JSON"'
           image: bitnami/kubectl:latest
           imagePullPolicy: Always
           name: deploy

--- a/server/src/kubernetes/kubernetes.service.ts
+++ b/server/src/kubernetes/kubernetes.service.ts
@@ -1309,9 +1309,12 @@ export class KubernetesService {
     job.spec.template.spec.initContainers[0].env[0].value = git.url;
     job.spec.template.spec.initContainers[0].env[1].value = git.ref;
     job.spec.template.spec.containers[0].env[0].value = repository.image;
-    job.spec.template.spec.containers[0].env[1].value =
-      repository.tag + '-' + id;
+    const tag = repository.tag + '-' + id;
+    job.spec.template.spec.containers[0].env[1].value = tag;
     job.spec.template.spec.containers[0].env[2].value = appName;
+    job.spec.template.spec.containers[0].env[3].value = JSON.stringify({
+      spec: { image: { repository: repository.image, tag: tag } },
+    });
 
     if (buildstrategy === 'buildpacks') {
       // configure build container


### PR DESCRIPTION
# Description

Pipelines currently fail with the following error message:

Error from server (BadRequest): error decoding patch: invalid character 's' looking for beginning of object key string

Is is due to improper escaping of JSON data in the patch. Fix this by holding the JSON in an environment variable, leaving proper escaping to the shell itself.

Fixes #710 

## Type of change

> Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run a build on my dev instance and it succeded

**Test Configuration**:

- Operator Version: v0.2.2
- Kubernetes Version: v1.34.0
- Kubero CLI Version (if applicable):

# Checklist:

- [x] I removed unnecessary debug logs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works
<!-- - [ ] New and existing unit tests pass locally with my changes
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->