### PR TITLE
add JWT based authentication for the registry

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -123,7 +123,8 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "moduleNameMapper": {
-      "^@octokit/core$": "<rootDir>/__mocks__/@octokit/core.js"
+      "^@octokit/core$": "<rootDir>/__mocks__/@octokit/core.js",
+      "^jose$": "<rootDir>/__mocks__/jose/core.js"
     },
     "setupFilesAfterEnv": [
       "<rootDir>/../jest-setup.js"

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -261,3 +261,14 @@ enum NotificationType {
   webhook
   discord
 }
+
+model RegistryUser {
+  id          String   @id @default(cuid())
+  username    String
+  password    String
+  scope       Json
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  expiresAt   DateTime?
+}

--- a/server/src/__mocks__/jose/core.js
+++ b/server/src/__mocks__/jose/core.js
@@ -1,0 +1,17 @@
+module.exports = {
+  importJWK: jest.fn().mockResolvedValue('mock-key'),
+  exportJWK: jest.fn().mockImplementation((v) => v),
+  SignJWT: jest.fn().mockImplementation((claims) => ({
+    setProtectedHeader: jest.fn().mockReturnThis(),
+    setIssuedAt: jest.fn().mockReturnThis(),
+    setIssuer: jest.fn().mockReturnThis(),
+    setSubject: jest.fn().mockReturnThis(),
+    setAudience: jest.fn().mockReturnThis(),
+    setExpirationTime: jest.fn().mockReturnThis(),
+    sign: jest.fn().mockResolvedValue('mock-jwt-token'),
+  })),
+  generateKeyPair: jest.fn().mockResolvedValue({ 
+    privateKey: {"kty":"EC","x":"fake","y":"fake","crv":"P-256","d":"fake"},
+    publicKey: {"kty":"EC","x":"fake","y":"fake","crv":"P-256"},
+  })
+};

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -25,6 +25,7 @@ import { GroupModule } from './groups/groups.module';
 import { RolesModule } from './roles/roles.module';
 import { TokenModule } from './token/token.module';
 import { CliModule } from './cli/cli.module';
+import { RegistryModule } from './registry/registry.module';
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { CliModule } from './cli/cli.module';
     RolesModule,
     TokenModule,
     CliModule,
+    RegistryModule
   ],
   controllers: [AppController, TemplatesController],
   providers: [AppService, TemplatesService],

--- a/server/src/apps/apps.module.ts
+++ b/server/src/apps/apps.module.ts
@@ -3,10 +3,12 @@ import { AppsService } from './apps.service';
 import { KubernetesModule } from '../kubernetes/kubernetes.module';
 import { AppsController } from './apps.controller';
 import { PipelinesService } from '../pipelines/pipelines.service';
+import { RegistryModule } from '../registry/registry.module';
 
 @Module({
   providers: [AppsService, KubernetesModule, PipelinesService],
   exports: [AppsService],
   controllers: [AppsController],
+  imports: [RegistryModule]
 })
 export class AppsModule {}

--- a/server/src/apps/apps.service.spec.ts
+++ b/server/src/apps/apps.service.spec.ts
@@ -10,6 +10,7 @@ import { IApp } from './apps.interface';
 import { IPodSize, ISecurityContext } from 'src/config/config.interface';
 import { IUser } from 'src/auth/auth.interface';
 import { IKubectlApp } from 'src/kubernetes/kubernetes.interface';
+import { RegistryService } from '../registry/registry.service';
 
 const podsize: IPodSize = {
   name: 'small',
@@ -122,6 +123,7 @@ describe('AppsService', () => {
   let notificationsService: jest.Mocked<NotificationsService>;
   let configService: jest.Mocked<ConfigService>;
   let eventsGateway: jest.Mocked<EventsGateway>;
+  let registryService: jest.Mocked<RegistryService>;
   const user: IUser = { id: '1', username: 'testuser' } as IUser;
 
   beforeEach(async () => {
@@ -153,6 +155,10 @@ describe('AppsService', () => {
           provide: EventsGateway,
           useValue: { execStreams: {}, sendTerminalLine: jest.fn() },
         },
+        {
+          provide: RegistryService,
+          useValue: { makeTemporaryPushCredentialsForImage: jest.fn() }
+        }
       ],
     }).compile();
 
@@ -162,6 +168,7 @@ describe('AppsService', () => {
     notificationsService = module.get(NotificationsService);
     configService = module.get(ConfigService);
     eventsGateway = module.get(EventsGateway);
+    registryService = module.get(RegistryService);
   });
 
   it('should be defined', () => {
@@ -225,6 +232,7 @@ describe('AppsService', () => {
   describe('triggerImageBuild', () => {
     it('should call createBuildJob', async () => {
       (pipelinesService.getContext as jest.Mock).mockResolvedValue('ctx');
+      (registryService.makeTemporaryPushCredentialsForImage as jest.Mock).mockResolvedValue({ username: 'fake', password: 'fake'});
       jest.spyOn(service, 'getApp').mockResolvedValue({
         spec: {
           gitrepo: { admin: true, ssh_url: 'repo' },
@@ -234,6 +242,7 @@ describe('AppsService', () => {
       } as any);
       await service.triggerImageBuild('p', 'ph', 'a', mockUSerGroups);
       expect(kubectl.createBuildJob).toHaveBeenCalled();
+      expect(registryService.makeTemporaryPushCredentialsForImage).toHaveBeenCalled();
     });
   });
 
@@ -334,6 +343,7 @@ describe('AppsService', () => {
         {} as any, // NotificationsService
         {} as any, // ConfigService
         mockEventsGateway,
+        {} as any, // RegistryService
       );
     });
 
@@ -450,6 +460,7 @@ describe('AppsService', () => {
         {} as any, // NotificationsService
         {} as any, // ConfigService
         {} as any, // EventsGateway
+        {} as any, // RegistryService
       );
     });
 
@@ -489,6 +500,7 @@ describe('AppsService', () => {
         {} as any, // NotificationsService
         {} as any, // configService
         {} as any, // eventsGateway
+        {} as any, // RegistryService
       );
       jest.spyOn(service, 'triggerImageBuild').mockResolvedValue({
         status: 'ok',
@@ -550,6 +562,7 @@ describe('AppsService', () => {
         {} as any, // NotificationsService
         {} as any, // configService
         {} as any, // eventsGateway
+        {} as any, // RegistryService
       );
       // Methoden ersetzen
       service.getAllAppsList = mockGetAllAppsList;
@@ -672,6 +685,7 @@ describe('AppsService', () => {
         mockNotificationsService,
         mockConfigService,
         {} as any,
+        {} as any, // RegistryService
       );
 
       service.createApp = jest.fn().mockResolvedValue(undefined);
@@ -893,6 +907,7 @@ describe('AppsService', () => {
         {} as any, // NotificationsService
         {} as any, // ConfigService
         {} as any, // eventsGateway
+        {} as any, // RegistryService
       );
 
       // Override the methods and properties
@@ -939,6 +954,7 @@ describe('AppsService', () => {
         mockNotificationsService,
         {} as any, // configService
         {} as any, // eventsGateway
+        {} as any, // RegistryService
       );
       service['logger'] = mockLogger;
     });
@@ -1026,6 +1042,7 @@ describe('AppsService', () => {
         {} as any, // NotificationsService
         {} as any, // ConfigService
         {} as any, // EventsGateway
+        {} as any, // RegistryService
       );
     });
 

--- a/server/src/apps/apps.service.ts
+++ b/server/src/apps/apps.service.ts
@@ -173,7 +173,8 @@ export class AppsService {
           ref: app.spec.branch, //git commit reference
         },
         {
-          image: `${process.env.KUBERO_BUILD_REGISTRY}/${pipeline}-${appName}`,
+          registry: process.env.KUBERO_BUILD_REGISTRY || "",
+          image: image,
           tag: app.spec.branch + '-' + timestamp,
         },
       );

--- a/server/src/deployments/deployments.module.ts
+++ b/server/src/deployments/deployments.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { DeploymentsController } from './deployments.controller';
 import { DeploymentsService } from './deployments.service';
-import { AppsService } from '../apps/apps.service';
-import { LogsService } from '../logs/logs.service';
+import { AppsModule } from '../apps/apps.module';
+import { LogsModule } from '../logs/logs.module';
+import { RegistryModule } from '../registry/registry.module';
 
 @Module({
   controllers: [DeploymentsController],
-  providers: [DeploymentsService, AppsService, LogsService],
+  imports: [AppsModule, LogsModule, RegistryModule],
+  providers: [DeploymentsService],
 })
 export class DeploymentsModule {}

--- a/server/src/deployments/deployments.service.spec.ts
+++ b/server/src/deployments/deployments.service.spec.ts
@@ -7,6 +7,7 @@ import { LogsService } from '../logs/logs.service';
 import { IUser } from '../auth/auth.interface';
 import { ILoglines } from 'src/logs/logs.interface';
 import { mockKubectlApp as app } from '../apps/apps.controller.spec';
+import { RegistryService } from 'src/registry/registry.service';
 
 const mockUserGroups = ['group1', 'group2'];
 
@@ -26,6 +27,7 @@ describe('DeploymentsService', () => {
   let pipelinesService: jest.Mocked<PipelinesService>;
   let logsService: jest.Mocked<LogsService>;
   let logLine: jest.Mocked<ILoglines>;
+  let registryService: jest.Mocked<RegistryService>;
 
   beforeEach(() => {
     kubectl = {
@@ -51,12 +53,17 @@ describe('DeploymentsService', () => {
       fetchLogs: jest.fn(),
     } as any;
 
+    registryService = {
+      makeTemporaryPushCredentialsForImage: jest.fn().mockResolvedValue({ username: 'fake', password: 'fake' }),
+    } as any;
+
     service = new DeploymentsService(
       kubectl,
       appsService,
       notificationsService,
       pipelinesService,
       logsService,
+      registryService
     );
 
     logLine = {

--- a/server/src/deployments/deployments.service.ts
+++ b/server/src/deployments/deployments.service.ts
@@ -139,6 +139,7 @@ export class DeploymentsService {
 
     // Create the Build CRD
     try {
+      const image = pipeline + '-' + app;
       await this.kubectl.createBuildJob(
         namespace,
         app,
@@ -150,7 +151,8 @@ export class DeploymentsService {
           url: gitrepo,
         },
         {
-          image: process.env.KUBERO_BUILD_REGISTRY + '/' + pipeline + '-' + app,
+          registry: process.env.KUBERO_BUILD_REGISTRY || "",
+          image: image,
           tag: reference,
         },
       );

--- a/server/src/deployments/templates/buildpacks.yaml.ts
+++ b/server/src/deployments/templates/buildpacks.yaml.ts
@@ -40,11 +40,12 @@ spec:
             value: "123456"
           - name: APP
             value: example
+          - name: PATCH_JSON
+            value: '{"spec":{"image":{"repository":"$REPOSITORY","tag": "$TAG"}}}'
           command:
           - sh
           - -c
-          - 'kubectl patch kuberoapps $APP --type=merge -p "{\"spec\":{\"image\":{\"repository\":
-            \"$REPOSITORY\",\"tag\": \"$TAG\"}}}"'
+          - 'kubectl patch kuberoapps $APP --type=merge -p "$PATCH_JSON"'
           image: bitnami/kubectl:latest
           imagePullPolicy: Always
           resources: {}

--- a/server/src/deployments/templates/dockerfile.yaml.ts
+++ b/server/src/deployments/templates/dockerfile.yaml.ts
@@ -41,11 +41,12 @@ spec:
             value: 123456
           - name: APP
             value: example
+          - name: PATCH_JSON
+            value: '{"spec":{"image":{"repository":"$REPOSITORY","tag": "$TAG"}}}'
           command:
           - sh
           - -c
-          - 'kubectl patch kuberoapps $APP --type=merge -p "{\"spec\":{\"image\":{\"repository\":
-            \"$REPOSITORY\",\"tag\": \"$TAG\"}}}"'
+          - 'kubectl patch kuberoapps $APP --type=merge -p "$PATCH_JSON"'
           image: bitnami/kubectl:latest
           imagePullPolicy: Always
           name: deploy

--- a/server/src/deployments/templates/nixpacks.yaml.ts
+++ b/server/src/deployments/templates/nixpacks.yaml.ts
@@ -41,11 +41,12 @@ spec:
             value: 123456
           - name: APP
             value: example
+          - name: PATCH_JSON
+            value: '{"spec":{"image":{"repository":"$REPOSITORY","tag": "$TAG"}}}'
           command:
           - sh
           - -c
-          - 'kubectl patch kuberoapps $APP --type=merge -p "{\"spec\":{\"image\":{\"repository\":
-            \"$REPOSITORY\",\"tag\": \"$TAG\"}}}"'
+          - 'kubectl patch kuberoapps $APP --type=merge -p "$PATCH_JSON"'
           image: bitnami/kubectl:latest
           imagePullPolicy: Always
           name: deploy

--- a/server/src/kubernetes/kubernetes.service.ts
+++ b/server/src/kubernetes/kubernetes.service.ts
@@ -1277,6 +1277,7 @@ export class KubernetesService {
       ref: string;
     },
     repository: {
+      registry: string;
       image: string;
       tag: string;
     },
@@ -1308,7 +1309,8 @@ export class KubernetesService {
     job.spec.template.spec.serviceAccount = appName + '-kuberoapp';
     job.spec.template.spec.initContainers[0].env[0].value = git.url;
     job.spec.template.spec.initContainers[0].env[1].value = git.ref;
-    job.spec.template.spec.containers[0].env[0].value = repository.image;
+    const imageUrl = repository.registry + '/' + repository.image
+    job.spec.template.spec.containers[0].env[0].value = imageUrl;
     job.spec.template.spec.containers[0].env[1].value =
       repository.tag + '-' + id;
     job.spec.template.spec.containers[0].env[2].value = appName;
@@ -1316,18 +1318,18 @@ export class KubernetesService {
     if (buildstrategy === 'buildpacks') {
       // configure build container
       job.spec.template.spec.initContainers[2].args[1] =
-        repository.image + ':' + repository.tag + '-' + id;
+        imageUrl + ':' + repository.tag + '-' + id;
     }
     if (buildstrategy === 'dockerfile') {
       // configure push container
       job.spec.template.spec.initContainers[1].env[1].value =
-        repository.image + ':' + repository.tag + '-' + id;
+        imageUrl + ':' + repository.tag + '-' + id;
       job.spec.template.spec.initContainers[1].env[2].value = dockerfilePath;
     }
     if (buildstrategy === 'nixpacks') {
       // configure push container
       job.spec.template.spec.initContainers[2].env[1].value =
-        repository.image + ':' + repository.tag + '-' + id;
+        imageUrl + ':' + repository.tag + '-' + id;
       job.spec.template.spec.initContainers[2].env[2].value = dockerfilePath;
     }
 

--- a/server/src/kubernetes/kubernetes.service.ts
+++ b/server/src/kubernetes/kubernetes.service.ts
@@ -1415,7 +1415,6 @@ export class KubernetesService {
     },
     //job: any, //V1Job,
   ): Promise<any> {
-    this.logger.error('refactoring: loadJob not implemented');
     const job = this.loadJob(buildstrategy) as any;
     //const job = new Object() as any;
 

--- a/server/src/kubernetes/kubernetes.service.ts
+++ b/server/src/kubernetes/kubernetes.service.ts
@@ -1448,9 +1448,12 @@ export class KubernetesService {
     job.spec.template.spec.initContainers[0].env[1].value = git.ref;
     const imageUrl = repository.registry + '/' + repository.image;
     job.spec.template.spec.containers[0].env[0].value = imageUrl;
-    job.spec.template.spec.containers[0].env[1].value =
-      repository.tag + '-' + id;
+    const tag = repository.tag + '-' + id;
+    job.spec.template.spec.containers[0].env[1].value = tag;
     job.spec.template.spec.containers[0].env[2].value = appName;
+    job.spec.template.spec.containers[0].env[3].value = JSON.stringify({
+      spec: { image: { repository: imageUrl, tag: tag } },
+    });
     job.spec.template.spec.volumes[2].secret.secretName = secretName;
 
     if (buildstrategy === 'buildpacks') {

--- a/server/src/logs/logs.module.ts
+++ b/server/src/logs/logs.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { LogsService } from './logs.service';
-import { AppsService } from 'src/apps/apps.service';
 import { LogsController } from './logs.controller';
+import { AppsModule } from '../apps/apps.module';
 
 @Module({
-  providers: [LogsService, AppsService],
+  providers: [LogsService],
   controllers: [LogsController],
+  imports: [AppsModule],
+  exports: [LogsService]
 })
 export class LogsModule {}

--- a/server/src/registry/registry.controller.ts
+++ b/server/src/registry/registry.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  UnauthorizedException,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+  Request,
+  Req,
+  Query,
+} from '@nestjs/common';
+import { RegistryService } from './registry.service';
+import { ConfigService } from 'src/config/config.service';
+
+@Controller({ path: 'api/registry', version: '1' })
+export class RegistryController {
+  private readonly logger = new Logger(RegistryController.name);
+
+  constructor(
+    private registryService: RegistryService,
+    private configService: ConfigService,
+  ) {}
+
+  private parseAuthHeader(authHeader: string) {
+    if (!authHeader) {
+      this.logger.verbose('auth header missing');
+      throw new UnauthorizedException('Authorization header is missing');
+    }
+
+    // Extract the base64-encoded credentials
+    const authData = authHeader.split(' ');
+    const authType = authData[0];
+    const base64Credentials = authData[1];
+    if (authType.toLowerCase() != 'basic' || !base64Credentials) {
+      this.logger.verbose('auth header invalid');
+      throw new UnauthorizedException('Invalid authorization header');
+    }
+
+    // Decode the credentials
+    const credentials = Buffer.from(base64Credentials, 'base64').toString(
+      'utf-8',
+    );
+    const [username, password] = credentials.split(':');
+
+    if (!username || !password) {
+      this.logger.verbose('invalid credentials');
+      throw new UnauthorizedException('Invalid credentials format');
+    }
+
+    return [username, password];
+  }
+
+  @Get('/token')
+  async getPipelineToken(
+    @Headers('authorization') authHeader: string,
+    @Query('service') service: string,
+    @Query('scope') scope: string | string[],
+  ) {
+    const [username, password] = this.parseAuthHeader(authHeader);
+
+    const jwt = await this.registryService.generateToken(
+      username,
+      password,
+      service,
+      scope,
+    );
+
+    return {
+      token: jwt,
+    };
+  }
+}

--- a/server/src/registry/registry.module.ts
+++ b/server/src/registry/registry.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { RegistryController } from './registry.controller';
+import { RegistryService } from './registry.service';
+import { ConfigModule } from '../config/config.module';
+import { PrismaClient } from '@prisma/client';
+import { KubernetesModule } from 'src/kubernetes/kubernetes.module';
+
+@Module({
+  controllers: [RegistryController],
+  providers: [RegistryService],
+  exports: [RegistryService],
+  imports: [ConfigModule, KubernetesModule, PrismaClient],
+})
+export class RegistryModule {}

--- a/server/src/registry/registry.service.spec.ts
+++ b/server/src/registry/registry.service.spec.ts
@@ -1,0 +1,291 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { RegistryService } from './registry.service';
+import { ConfigService } from '../config/config.service';
+import { PrismaClient } from '@prisma/client';
+import { SignJWT } from 'jose';
+import { KubernetesService } from '../kubernetes/kubernetes.service';
+
+describe('RegistryService', () => {
+  let service: RegistryService;
+  let configService: ConfigService;
+  let prismaMock = {
+    registryUser: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+  const registryConfigBase = {
+    host: 'someservice',
+    port: 5000,
+    enabled: true,
+    create: false,
+    storage: '1Gi',
+    storageClassName: null,
+    subpath: '',
+    account: {
+      username: 'admin',
+      password: 'password',
+      hash: 'hash',
+    },
+  };
+  const registryPullUser = {
+    username: 'fake',
+    password: '$2b$10$SVulDccp3nXVJJv7fNLYZOHqDW./xumFwMDX0MfH6X47dThPiWRLy', // password
+    expiresAt: null,
+    scope: {
+      allowedScopes: [
+        { type: 'repository', name: 'test/image', actions: ['pull'] },
+      ],
+    },
+  };
+  const fakePrivateKey =
+    '{"kty":"EC","x":"fake","y":"fake","crv":"P-256","d":"fake"}';
+  const fakePublicKey = '{"kty":"EC","x":"fake","y":"fake","crv":"P-256"}';
+  const fakeRegistryLogin = {
+    usename: 'fake',
+    password: 'password',
+    '.dockerconfigjson': JSON.stringify({
+      auths: {
+        someservice: {
+          auth: Buffer.from('fake:password').toString('base64'),
+        },
+      },
+    }),
+  };
+  let kubernetesMock = {
+    upsertSecret: jest.fn(),
+    getSecret: jest.fn().mockImplementation((secretName) => {
+      switch (secretName) {
+        case 'registry-jwt-pubkey':
+          return {
+            jwk: fakePublicKey,
+          };
+        case 'registry-jwt-privkey':
+          return {
+            privateKey: fakePrivateKey,
+            publicKey: fakePublicKey,
+          };
+        case 'registry-login':
+          return fakeRegistryLogin;
+      }
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegistryService,
+        {
+          provide: PrismaClient,
+          useValue: prismaMock,
+        },
+        {
+          provide: KubernetesService,
+          useValue: kubernetesMock,
+        },
+      ],
+    })
+      .setLogger(new Logger())
+      .compile();
+
+    service = module.get<RegistryService>(RegistryService);
+    process.env.KUBERO_BUILD_REGISTRY = 'someservice';
+  });
+
+  describe('onApplicationBootstrap', () => {
+    it('should try to create private and public JWK when both are missing', async () => {
+      //jest.clearAllMocks();
+      let upsertSecretSpy = jest.spyOn(kubernetesMock, 'upsertSecret');
+      let getSecretSpy = jest.spyOn(kubernetesMock, 'getSecret');
+      getSecretSpy.mockImplementation((secretName) => {
+        switch (secretName) {
+          case 'registry-jwt-privkey':
+            return null;
+          case 'registry-jwt-pubkey':
+            return null;
+          case 'registry-login':
+            return fakeRegistryLogin;
+        }
+      });
+      await service.onApplicationBootstrap();
+
+      expect(upsertSecretSpy).toHaveBeenNthCalledWith(
+        1,
+        'registry-jwt-privkey',
+        expect.objectContaining({
+          privateKey: expect.any(String),
+          publicKey: expect.any(String),
+        }),
+      );
+      expect(upsertSecretSpy).toHaveBeenNthCalledWith(
+        2,
+        'registry-jwt-pubkey',
+        expect.objectContaining({
+          jwk: expect.any(String),
+        }),
+      );
+      jest.restoreAllMocks();
+    });
+    it('should create the public key for the registry when a private key is present', async () => {
+      //jest.clearAllMocks();
+      let upsertSecretSpy = jest.spyOn(kubernetesMock, 'upsertSecret');
+      let getSecretSpy = jest.spyOn(kubernetesMock, 'getSecret');
+      getSecretSpy.mockImplementation((secretName) => {
+        switch (secretName) {
+          case 'registry-jwt-privkey':
+            return {
+              privateKey: fakePrivateKey,
+              publicKey: fakePublicKey,
+            };
+          case 'registry-jwt-pubkey':
+            return null;
+        }
+      });
+      await service.onApplicationBootstrap();
+      expect(upsertSecretSpy).toHaveBeenCalledWith('registry-jwt-pubkey', {
+        jwk: fakePublicKey,
+      });
+    });
+  });
+
+  describe('generateToken', () => {
+    beforeEach(async () => {
+      await service.onApplicationBootstrap();
+    });
+
+    it('should throw an exception when service does not match the registry host name', async () => {
+      await expect(
+        service.generateToken(
+          'fake',
+          'password',
+          'wrongservice',
+          'repository:test/image:pull',
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(prismaMock.registryUser.findFirst).toHaveBeenCalledTimes(0);
+    });
+
+    it('should throw an unauthorized exception when the user is not found', async () => {
+      prismaMock.registryUser.findFirst.mockResolvedValueOnce(null);
+      await expect(
+        service.generateToken(
+          'fake',
+          'password',
+          'someservice',
+          'repository:test/image:pull',
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(prismaMock.registryUser.findFirst).toHaveBeenCalled();
+    });
+
+    it('should throw an unauthorized exception when the user is expired', async () => {
+      let expiredUser = {
+        username: 'fake',
+        password:
+          '$2b$10$SVulDccp3nXVJJv7fNLYZOHqDW./xumFwMDX0MfH6X47dThPiWRLy', // password
+        expiresAt: new Date(1991, 1, 1, 23, 59, 59),
+        scope: [],
+      };
+      prismaMock.registryUser.findFirst.mockResolvedValueOnce(expiredUser);
+      await expect(
+        service.generateToken(
+          'fake',
+          'password',
+          'someservice',
+          'repository:test/image:pull',
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(prismaMock.registryUser.findFirst).toHaveBeenCalled();
+    });
+
+    var testTokenMismatch = async (
+      permission: { type; name; action },
+      requestedScope: string,
+    ) => {
+      const testUser = {
+        username: 'fake',
+        password:
+          '$2b$10$SVulDccp3nXVJJv7fNLYZOHqDW./xumFwMDX0MfH6X47dThPiWRLy', // password
+        expiresAt: null,
+        scope: [permission],
+      };
+      prismaMock.registryUser.findFirst.mockResolvedValueOnce(testUser);
+
+      const result = await service.generateToken(
+        'fake',
+        'password',
+        'someservice',
+        requestedScope,
+      );
+
+      expect(result).toBe('mock-jwt-token');
+      expect(SignJWT).toHaveBeenCalledWith({ access: [] });
+      expect(prismaMock.registryUser.findFirst).toHaveBeenCalled();
+    };
+
+    it('should return a JWT with empty scope when the image name in permissions and requestedScopes does not match', async () => {
+      await testTokenMismatch(
+        {
+          type: 'repository',
+          name: { kind: 'exact', name: 'test/image' },
+          action: ['pull'],
+        },
+        'repository:test/otherimage:pull',
+      );
+    });
+
+    it('should return a JWT with empty scope when the action in permissions and requestedScopes does not match', async () => {
+      await testTokenMismatch(
+        {
+          type: 'repository',
+          name: { kind: 'exact', name: 'test/image' },
+          action: ['pull'],
+        },
+        'repository:test/image:push',
+      );
+    });
+
+    it('should return a JWT with empty scope when the type in permissions and requestedScopes does not match', async () => {
+      await testTokenMismatch(
+        {
+          type: 'repository',
+          name: { kind: 'exact', name: 'test/image' },
+          action: ['pull'],
+        },
+        'registry:test/image:pull',
+      );
+    });
+
+    it('should return a JWT with correct scope when allowedScopes and requestedScopes match', async () => {
+      let testUser = {
+        username: 'fake',
+        password:
+          '$2b$10$SVulDccp3nXVJJv7fNLYZOHqDW./xumFwMDX0MfH6X47dThPiWRLy', // password
+        expiresAt: null,
+        scope: [
+          { type: 'repository', name: 'test/image', actions: ['pull', 'push'] },
+        ],
+      };
+      prismaMock.registryUser.findFirst.mockResolvedValueOnce(testUser);
+
+      // action is intentionally swapped
+      const result = await service.generateToken(
+        'fake',
+        'password',
+        'someservice',
+        `repository:test/image:push,pull`,
+      );
+
+      expect(result).toBe('mock-jwt-token');
+      expect(SignJWT).toHaveBeenCalledWith({
+        access: [
+          { type: 'repository', name: 'test/image', actions: ['pull', 'push'] },
+        ],
+      });
+      expect(prismaMock.registryUser.findFirst).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/registry/registry.service.ts
+++ b/server/src/registry/registry.service.ts
@@ -1,0 +1,545 @@
+import {
+  Injectable,
+  Logger,
+  NotImplementedException,
+  OnApplicationBootstrap,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import { randomBytes, randomUUID } from 'crypto';
+import { importJWK, exportJWK, JWK, SignJWT, generateKeyPair } from 'jose';
+import { KubernetesService } from '../kubernetes/kubernetes.service';
+import { truncate } from 'fs/promises';
+import { truncateSync } from 'fs';
+
+interface NameMatchExact {
+  kind: 'exact';
+  name: string;
+}
+
+interface NameMatchAny {
+  kind: 'any';
+}
+
+type NameMatch = NameMatchExact | NameMatchAny;
+
+type PermissionType = 'repository';
+
+/**
+ * This class models a permission that is granted to a RegistryUser.
+ */
+export class Permission {
+  public actions: Set<string>;
+
+  constructor(
+    public type: PermissionType,
+    public name: NameMatch,
+    actions: Set<string> | string[],
+  ) {
+    this.actions = actions instanceof Set ? actions : new Set(actions);
+  }
+
+  toObject() {
+    return {
+      type: this.type,
+      name:
+        this.name.kind === 'exact'
+          ? { kind: 'exact' as const, name: this.name.name }
+          : { kind: 'any' as const },
+      actions: Array.from(this.actions),
+    };
+  }
+
+  equals(other: Permission) {
+    if (this.type !== other.type) {
+      return false;
+    }
+
+    if (this.name.kind !== other.name.kind) {
+      return false;
+    }
+
+    return (
+      Array.from(this.actions.values()).sort() ==
+      Array.from(other.actions.values()).sort()
+    );
+  }
+
+  static fromObject(obj: any): Permission {
+    const actions = Array.isArray(obj.actions)
+      ? new Set<string>(obj.actions)
+      : new Set<string>();
+
+    const name: NameMatch =
+      obj.name?.kind === 'exact'
+        ? { kind: 'exact', name: obj.name.name }
+        : { kind: 'any' };
+
+    return new Permission(obj.type, name, actions);
+  }
+
+  static fromObjectArray(objArray: any): Permission[] {
+    if (!Array.isArray(objArray)) {
+      return [];
+    }
+    return objArray.map((obj) => Permission.fromObject(obj));
+  }
+}
+
+/**
+ * This class models a Scope that is requested by the registry.
+ */
+export class RegistryScope {
+  constructor(
+    public type: string,
+    public name: string,
+    public actions: Set<string>,
+  ) {}
+
+  toObject() {
+    return {
+      type: this.type,
+      name: this.name,
+      actions: Array.from(this.actions),
+    };
+  }
+
+  static fromObject(obj: any): RegistryScope {
+    const actions = Array.isArray(obj.actions)
+      ? new Set<string>(obj.actions)
+      : new Set<string>();
+    return new RegistryScope(obj.type, obj.name, actions);
+  }
+
+  static fromObjectArray(objArray: any): RegistryScope[] {
+    if (!Array.isArray(objArray)) {
+      return [];
+    }
+    return objArray.map((obj) => RegistryScope.fromObject(obj));
+  }
+}
+
+@Injectable()
+export class RegistryService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RegistryService.name);
+
+  private jwk: CryptoKeyPair;
+
+  private registryHostname: string;
+
+  private readonly jwk_algo = 'ES256';
+
+  constructor(
+    private prisma: PrismaClient,
+    private kubectl: KubernetesService,
+  ) {}
+
+  public async onApplicationBootstrap() {
+    if (!process.env.KUBERO_BUILD_REGISTRY) {
+      return;
+    }
+    this.registryHostname = process.env.KUBERO_BUILD_REGISTRY;
+    await this.maybeProvisionRegistryJwk();
+    await this.maybeProvisionPullCredential();
+  }
+
+  private async maybeProvisionRegistryJwk() {
+    const tryJwk = await this.tryGetRegistryJwkPrivate();
+    if (!tryJwk) {
+      this.logger.log(
+        'Private JWK for registry not found in kubernetes or invalid; generating one',
+      );
+      this.jwk = await this.provisionRegistryJwkPrivate();
+    } else {
+      this.jwk = tryJwk;
+    }
+
+    if (!(await this.isRegistryJwkPublicValid())) {
+      this.logger.log(
+        "Public JWK not found in kubernetes, invalid or doesn't match private key; provisioning from privatekey",
+      );
+      await this.kubectl.upsertSecret('registry-jwt-pubkey', {
+        jwk: JSON.stringify(this.jwk.publicKey),
+      });
+    }
+  }
+
+  private jwkPubkeysEqual(keyA, keyB) {
+    return (
+      keyA.crv === keyB.crv &&
+      keyA.kty === keyB.kty &&
+      keyA.x === keyB.x &&
+      keyA.y === keyB.y
+    );
+  }
+
+  private async isRegistryJwkPublicValid() {
+    let secretJwkPublic = await this.kubectl.getSecret('registry-jwt-pubkey');
+    if (!secretJwkPublic || !secretJwkPublic.jwk) {
+      return false;
+    }
+
+    let jwkPublic = JSON.parse(secretJwkPublic.jwk);
+    if (!jwkPublic) {
+      return false;
+    }
+    return this.jwkPubkeysEqual(jwkPublic, this.jwk.publicKey);
+  }
+
+  private async tryGetRegistryJwkPrivate(): Promise<null | CryptoKeyPair> {
+    let secretJwkPrivate = await this.kubectl.getSecret('registry-jwt-privkey');
+    if (!secretJwkPrivate || !secretJwkPrivate.privateKey) {
+      return null;
+    }
+    const jwkPrivateJson = JSON.parse(secretJwkPrivate.privateKey);
+    if (!jwkPrivateJson) {
+      return null;
+    }
+
+    if (!secretJwkPrivate.publicKey) {
+      return null;
+    }
+
+    const jwkPublicJson = JSON.parse(secretJwkPrivate.publicKey);
+    if (!jwkPublicJson) {
+      return null;
+    }
+
+    return {
+      publicKey: jwkPublicJson,
+      privateKey: jwkPrivateJson,
+    };
+  }
+
+  private async provisionRegistryJwkPrivate(): Promise<{
+    privateKey: CryptoKey;
+    publicKey: CryptoKey;
+  }> {
+    const generatedKey = await generateKeyPair(this.jwk_algo, {
+      extractable: true,
+    });
+    const exportedPrivateKey = await exportJWK(generatedKey.privateKey);
+    const exportedPublicKey = await exportJWK(generatedKey.publicKey);
+
+    this.kubectl.upsertSecret('registry-jwt-privkey', {
+      privateKey: JSON.stringify(exportedPrivateKey),
+      publicKey: JSON.stringify(exportedPublicKey),
+    });
+
+    return generatedKey;
+  }
+
+  public async addRegistryUser(
+    username: string,
+    password: string,
+    permissions: Permission[],
+  ) {
+    // TODO expiration
+    await this.prisma.registryUser.create({
+      data: {
+        username: username,
+        password: bcrypt.hashSync(password, 10),
+        scope: permissions.map((p) => p.toObject()),
+      },
+    });
+  }
+
+  private randomPassword() {
+    return randomBytes(30).toString('base64').substring(0, 30);
+  }
+
+  public async makeTemporaryPushCredentialsForImage(
+    authorizedImage: string,
+  ): Promise<{ username: string; password: string }> {
+    const registryUsername = randomUUID();
+    const registryPassword = this.randomPassword();
+    const permission = new Permission(
+      'repository',
+      { kind: 'exact', name: authorizedImage },
+      new Set(['pull', 'push']),
+    );
+    this.addRegistryUser(registryUsername, registryPassword, [permission]);
+
+    return {
+      username: registryUsername,
+      password: registryPassword,
+    };
+  }
+
+  private parseScope(scope: String) {
+    const [ressourceType, ressourceName, ressourceActionStr] = scope.split(':');
+    if (!ressourceType || !['repository', 'registry'].includes(ressourceType)) {
+      this.logger.debug(
+        `parseScope: missing or invalid ressourceType "${ressourceType}"`,
+      );
+      return null;
+    }
+
+    if (!ressourceName || !ressourceActionStr) {
+      this.logger.debug(
+        `parseScope: missing ressourceName "${ressourceName}" or ressourceActionStr "${ressourceActionStr}`,
+      );
+      return null;
+    }
+
+    const ressourceActions = new Set<string>(ressourceActionStr.split(','));
+
+    return new RegistryScope(ressourceType, ressourceName, ressourceActions);
+  }
+
+  private parseRequestedScopes(scope: string | string[]) {
+    const requestedScopes = Array.isArray(scope) ? scope : [scope];
+    const parsedScopes: Array<RegistryScope> = [];
+
+    for (const scopeStr of requestedScopes) {
+      const parsed = this.parseScope(scopeStr);
+      if (!parsed) {
+        throw new UnauthorizedException('Invalid scope format');
+      }
+      parsedScopes.push(parsed);
+    }
+
+    return parsedScopes;
+  }
+
+  /**
+   * Find the scopes in requestedScopes that are authorized by the given permissions.
+   * @param requestedScopes the scopes to check the permissions against
+   * @param permissions the permissions the user has
+   * @returns the requestedScopes that are covered by the given permissions
+   */
+  private findAuthorizedScopes(
+    requestedScopes: RegistryScope[],
+    permissions: Permission[],
+  ): Array<RegistryScope> {
+    const grantedScopes: RegistryScope[] = [];
+
+    for (const requestedScope of requestedScopes) {
+      // Find matching permission by type and name
+      const matchingPermission = permissions.find((permission: Permission) => {
+        if (permission.type != requestedScope.type) {
+          return false;
+        }
+        switch (permission.name.kind) {
+          case 'any':
+            return true;
+          case 'exact':
+            return requestedScope.name == permission.name.name;
+          default:
+            throw new NotImplementedException();
+        }
+      });
+
+      if (!matchingPermission) {
+        // Skip scopes that don't have a matching permission
+        continue;
+      }
+
+      // Compute intersection of actions
+      const allowedActions = matchingPermission.actions || [];
+      let grantedActions = new Set<string>();
+      for (const a of allowedActions) {
+        if (requestedScope.actions.has(a)) {
+          grantedActions.add(a);
+        }
+      }
+
+      // Only include scope if at least one action is granted
+      if (grantedActions.size > 0) {
+        grantedScopes.push(
+          new RegistryScope(
+            matchingPermission.type,
+            // use the name from the requestedScope since the permission may have a match-all for the name
+            requestedScope.name,
+            grantedActions,
+          ),
+        );
+      }
+    }
+
+    return grantedScopes;
+  }
+
+  async generateToken(
+    username: string,
+    password: string,
+    service: string,
+    scope: string | string[],
+  ): Promise<string> {
+    if (service !== this.registryHostname) {
+      this.logger.verbose(
+        `invalid service: ${service} != ${this.registryHostname}`,
+      );
+      throw new UnauthorizedException('Invalid service');
+    }
+
+    const registryUser = await this.verifyPassword(username, password);
+    if (!registryUser) {
+      this.logger.verbose(`invalid credentials: ${registryUser}`);
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const parsedScopes = this.parseRequestedScopes(scope);
+
+    const allowedScopes = Permission.fromObjectArray(registryUser.scope);
+
+    const grantedScopes = this.findAuthorizedScopes(
+      parsedScopes,
+      allowedScopes,
+    );
+
+    return this.signJwt(username, grantedScopes);
+  }
+
+  private async signJwt(subjectName: string, grantedScopes: RegistryScope[]) {
+    const jwtprivkeystr = JSON.parse(
+      process.env.KUBERO_REGISTRY_JWT_KEY_PRIVATE || '{}',
+    );
+    const jwtprivkey = await importJWK(jwtprivkeystr, this.jwk_algo);
+
+    var token = await new SignJWT({
+      access: grantedScopes.map((scope) => scope.toObject()),
+    })
+      .setProtectedHeader({ alg: this.jwk_algo, kid: '0' })
+      .setIssuedAt()
+      .setIssuer('todo.kubero.dev') // TODO
+      .setSubject(subjectName)
+      .setAudience(this.registryHostname)
+      .setExpirationTime('3h') // TODO clamp to user expiration
+      .sign(jwtprivkey);
+
+    return token;
+  }
+
+  private async verifyPassword(username: string, password: string) {
+    const registryUser = await this.prisma.registryUser.findFirst({
+      where: { username: username },
+    });
+
+    if (!registryUser) {
+      return null;
+    }
+    const isUserExpired =
+      registryUser.expiresAt && registryUser.expiresAt < new Date();
+    if (isUserExpired) {
+      return null;
+    }
+
+    const isPasswordValid = await bcrypt.compare(
+      password,
+      registryUser.password,
+    );
+    if (!isPasswordValid) {
+      return null;
+    }
+
+    return registryUser;
+  }
+
+  private async isPullCredentialValid() {
+    const pullCredentials = await this.kubectl.getSecret('registry-login');
+
+    if (
+      !pullCredentials ||
+      !pullCredentials.username ||
+      !pullCredentials.password ||
+      !pullCredentials['.dockerconfigjson']
+    ) {
+      return false;
+    }
+
+    const pullUser = await this.verifyPassword(
+      pullCredentials.username,
+      pullCredentials.password,
+    );
+    if (!pullUser) {
+      return false;
+    }
+
+    if (!Array.isArray(pullUser.scope) || !pullUser.scope.length) {
+      return false;
+    }
+
+    const permission = Permission.fromObject(pullUser.scope[0]);
+    if (
+      !permission ||
+      !permission.equals(
+        new Permission(
+          'repository',
+          { kind: 'any' },
+          new Set<string>(['pull']),
+        ),
+      )
+    ) {
+      return false;
+    }
+
+    const dockerconfig = JSON.parse(pullCredentials['.dockerconfigjson']);
+    if (
+      !dockerconfig ||
+      !dockerconfig.auths ||
+      typeof dockerconfig.auths !== 'object'
+    ) {
+      return false;
+    }
+
+    if (!dockerconfig.auths[this.registryHostname]) {
+      return false;
+    }
+
+    const auth = dockerconfig.auths[this.registryHostname].auth;
+    const expectedAuth = this.encodeCredentialsDockerAuthConfig(
+      pullCredentials.username,
+      pullCredentials.password,
+    );
+    return auth === expectedAuth;
+  }
+
+  private encodeCredentialsDockerAuthConfig(
+    username: string,
+    password: string,
+  ) {
+    const authString = `${username}:${password}`;
+    return Buffer.from(authString).toString('base64');
+  }
+
+  private makeDockerAuthConfig(username: string, password: string) {
+    return {
+      auths: {
+        [this.registryHostname]: {
+          auth: this.encodeCredentialsDockerAuthConfig(username, password),
+        },
+      },
+    };
+  }
+
+  private async maybeProvisionPullCredential() {
+    if (await this.isPullCredentialValid()) {
+      return;
+    }
+
+    this.logger.log(
+      'No pull credentials for kubernetes found or credentials invalid, creating.',
+    );
+
+    const password = this.randomPassword();
+    const username = `k8s-pull-${randomUUID()}`;
+    const permission = new Permission(
+      'repository',
+      { kind: 'any' },
+      new Set<string>(['pull']),
+    );
+    this.addRegistryUser(username, password, [permission]);
+
+    const secret = {
+      username,
+      password,
+      '.dockerconfigjson': JSON.stringify(
+        this.makeDockerAuthConfig(username, password),
+      ),
+    };
+
+    await this.kubectl.upsertSecret('registry-login', secret);
+  }
+}

--- a/server/src/repo/repo.module.ts
+++ b/server/src/repo/repo.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { RepoController } from './repo.controller';
 import { RepoService } from './repo.service';
-import { AppsService } from 'src/apps/apps.service';
+import { AppsModule } from '../apps/apps.module';
 
 @Module({
   controllers: [RepoController],
-  providers: [RepoService, AppsService],
+  providers: [RepoService],
+  imports: [AppsModule],
 })
 export class RepoModule {}

--- a/server/src/security/security.module.ts
+++ b/server/src/security/security.module.ts
@@ -3,9 +3,10 @@ import { SecurityController } from './security.controller';
 import { SecurityService } from './security.service';
 import { KubernetesModule } from '../kubernetes/kubernetes.module';
 import { PipelinesModule } from '../pipelines/pipelines.module';
-import { AppsService } from '../apps/apps.service';
+import { AppsModule} from '../apps/apps.module';
 @Module({
   controllers: [SecurityController],
-  providers: [SecurityService, KubernetesModule, PipelinesModule, AppsService],
+  imports: [AppsModule],
+  providers: [SecurityService, KubernetesModule, PipelinesModule],
 })
 export class SecurityModule {}

--- a/server/src/status/status.module.ts
+++ b/server/src/status/status.module.ts
@@ -6,7 +6,7 @@ import {
 } from '@willsoto/nestjs-prometheus';
 import { StatusService } from './status.service';
 import { ScheduleModule } from '@nestjs/schedule';
-import { AppsService } from '../apps/apps.service';
+import { AppsModule } from '../apps/apps.module';
 import { StatusController } from './status.controller';
 
 @Module({
@@ -15,10 +15,10 @@ import { StatusController } from './status.controller';
       controller: StatusController,
     }),
     ScheduleModule.forRoot(),
+    AppsModule
   ],
   providers: [
     StatusService,
-    AppsService,
     makeGaugeProvider({
       name: 'kubero_pipelines_total',
       help: 'Total number of pipelines',


### PR DESCRIPTION
# Description

Currently, the registry for GitOps based deployments is protected with basic authentication. Basic authentication is simple, but may not be the best choice for multi user environments since it doesn't seem to work properly if the user doesn't have the `config:read` permission (and giving that permission to arbitrary non-admins seems like a bad idea).

This PR depends on [changes in the operator](https://github.com/kubero-dev/kubero-operator/pull/55) to use [Token Authentication in the distribution registry](https://distribution.github.io/distribution/spec/auth/token/). This PR implements a "Authorization service" (see link above) in the Kubero UI. This delegates the registry authorization to Kubero and allows us to grant minimal privileges to each build job. 

The authentication for build jobs works like this:

- when a build job is created, a `RegistryUser` is created with a randomly generated password and stored in the database
  - this is done in `makeTemporaryPushCredentialsForImage()` 
- these credentials are stored in a kubernetes secret
- build job starts, buildah builds and finally tries to push the image to the registry
- the registry will reply with `401 Unauthorized` and ask buildah to call back to the Kubero UI
- buildah will supply the credentials from the kubernetes secret above
- Kubero UI checks username, password and permissions. if everything is OK, it issues a JWT authorizing access
- the registry validates the JWT and grants access if everything is OK

For the JWT to work, the registry needs access to the public part of the JWK used to sign the JWT. This is done in `onApplicationBootstrap` of the `RegistryService`. 

In addition, we also need a credential authorizing kubernetes to pull images for spinning up pods. This is also created in `onApplicationBootstrap`.

The PR is currently marked as draft to solicit feedback on the approach. It is missing:

- I think trivy image scans are broken now, but that should be easy enough to fix
- some naming isn't ideal yet
- `RegistryUsers` don't expire
- issued JWTs aren't clamped to the user's expiration date
- kubernetes secrets with `RegistryUsers` should be deleted when a build is done

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Marking as a breaking change since existing registry with basic authentication would stop working and need to be migrated. However, token authentication is very flexible and in the future we could add a UI to create arbitrary registry users if that is a known use case we don't want to break.

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I have build the operator with my changes, deployed it in a kind cluster and kicked off a build which worked fine.

- [x] I've built the image and tested it on a kubernetes cluster

**Test Configuration**:

- Operator Version - requires operator changes see PR there
- Kubernetes Version: 1.34.0
- Kubero CLI Version (if applicable): n/a

# Checklist:

- [x] I removed unnecessary debug logs
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
