### PR TITLE
fix(repo): prevent GitHub API calls when GitHub is not configured

### DIFF
--- a/client/src/components/pipelines/form.vue
+++ b/client/src/components/pipelines/form.vue
@@ -631,6 +631,7 @@ export default defineComponent({
         gogs: false,
         docker: true
       },
+      repositoriesListLoaded: false, // flag to indicate if repositoriesList has been loaded
       git: {
         keys: {},
         repository: {},
@@ -721,11 +722,12 @@ export default defineComponent({
     },
     mounted() {
       this.getContextList();
-      this.listRepositories();
+      this.listRepositories().then(() => {
+        this.loadRepository();
+        this.loadPipeline();
+      });
       this.loadDefaultregistry();
       this.listBuildpacks();
-      this.loadRepository();
-      this.loadPipeline();
     },
     components: {
         Breadcrumbs,
@@ -747,10 +749,18 @@ export default defineComponent({
           }
         });
       },
-      listRepositories() {
-        axios.get('/api/repo/providers').then(response => {
-          this.repositoriesList = response.data
-        });
+      async listRepositories() {
+        const response = await axios.get('/api/repo/providers');
+        this.repositoriesList = response.data
+        this.repositoriesListLoaded = true;
+        // Set default repotab to first enabled provider (not github by default)
+        const providers = ['github', 'gitea', 'gitlab', 'gogs', 'bitbucket'];
+        for (const provider of providers) {
+          if (this.repositoriesList[provider as keyof typeof this.repositoriesList] === true) {
+            this.repotab = provider;
+            break;
+          }
+        }
       },
       listBuildpacks() {
         axios.get('/api/config/runpacks').then(response => {
@@ -827,6 +837,10 @@ export default defineComponent({
       },
 
       loadRepository() {
+        // Only load repositories if the selected provider is enabled
+        if (!this.repositoriesList[this.repotab as keyof typeof this.repositoriesList]) {
+          return;
+        }
         axios.get(`/api/repo/${this.repotab}/repositories`)
         .then(response => {
           this.gitrepoItems = response.data;

--- a/server/src/repo/git/github.ts
+++ b/server/src/repo/git/github.ts
@@ -17,11 +17,14 @@ import { RequestError } from '@octokit/types';
 
 export class GithubApi extends Repo {
   private octokit: any;
+  private token: string;
 
   constructor(baseUrl: string, token: string) {
     super('github');
 
-    if (baseUrl === '') {
+    this.token = token;
+
+    if (!baseUrl || baseUrl === '') {
       baseUrl = 'https://api.github.com';
     }
 
@@ -29,6 +32,10 @@ export class GithubApi extends Repo {
       auth: token,
       baseUrl: baseUrl,
     });
+  }
+
+  private isConfigured(): boolean {
+    return !!this.token && this.token !== '';
   }
 
   protected async getRepository(gitrepo: string): Promise<IRepository> {
@@ -42,6 +49,11 @@ export class GithubApi extends Repo {
         push: false,
       },
     };
+
+    if (!this.isConfigured()) {
+      this.logger.debug('GitHub API is not configured, skipping getRepository');
+      return ret;
+    }
 
     const parsed = gitUrlParse(gitrepo);
     const repo = parsed.name;
@@ -92,6 +104,10 @@ export class GithubApi extends Repo {
   }
 
   public async getRepositories() {
+    if (!this.isConfigured()) {
+      this.logger.debug('GitHub API is not configured, skipping getRepositories');
+      return [];
+    }
     const res = await this.octokit.request('GET /user/repos', {});
     return res.data;
   }
@@ -308,6 +324,10 @@ export class GithubApi extends Repo {
 
   public async listRepos(): Promise<string[]> {
     const ret: string[] = [];
+    if (!this.isConfigured()) {
+      this.logger.debug('GitHub API is not configured, skipping listRepos');
+      return ret;
+    }
     try {
       const repos = await this.octokit.request('GET /user/repos', {
         visibility: 'all',
@@ -325,6 +345,10 @@ export class GithubApi extends Repo {
 
   public async getBranches(gitrepo: string): Promise<string[]> {
     const ret: string[] = [];
+    if (!this.isConfigured()) {
+      this.logger.debug('GitHub API is not configured, skipping getBranches');
+      return ret;
+    }
 
     const { repo, owner } = this.parseRepo(gitrepo);
 
@@ -348,6 +372,10 @@ export class GithubApi extends Repo {
 
   public async getReferences(gitrepo: string): Promise<string[]> {
     const ret: string[] = [];
+    if (!this.isConfigured()) {
+      this.logger.debug('GitHub API is not configured, skipping getReferences');
+      return ret;
+    }
 
     const { repo, owner } = this.parseRepo(gitrepo);
 
@@ -401,6 +429,10 @@ export class GithubApi extends Repo {
 
   public async getPullrequests(gitrepo: string): Promise<IPullrequest[]> {
     const ret: IPullrequest[] = [];
+    if (!this.isConfigured()) {
+      this.logger.debug('GitHub API is not configured, skipping getPullrequests');
+      return ret;
+    }
 
     const { repo, owner } = this.parseRepo(gitrepo);
 


### PR DESCRIPTION
## Summary

This PR fixes issue #625 where Kubero was making calls to GitHub APIs even when GitHub was disabled (no PAT set) and only Gitea was configured.

## Problem

On Kubero v2.4.6, when setting up a pipeline with Gitea as the only configured provider:
- Even with GitHub disabled (PAT not set), Kubero was still making calls to GitHub APIs and failing
- Kubero was also making HTTP calls to the GitHub APIs with Gitea repository paths

## Root Causes

1. **Client-side**: The default selected tab (`repotab`) was hardcoded to `'github'` regardless of which providers were actually enabled
2. **Server-side**: The GitHub API constructor didn't properly handle undefined `baseUrl` values (the check `if (baseUrl === '')` missed undefined values)
3. **Server-side**: All GitHub API methods would try to make HTTP requests even when no token was configured

## Changes

### Client (`client/src/components/pipelines/form.vue`)
- Made `listRepositories()` async and wait for provider list to load before setting default tab
- Set default tab to first enabled provider instead of hardcoding 'github'
- Added guard in `loadRepository()` to skip API calls if the selected provider is not enabled

### Server (`server/src/repo/git/github.ts`)
- Fixed `baseUrl` check to handle both empty string and falsy/undefined values
- Added `token` property and `isConfigured()` method to check if the API is properly configured
- Added configuration guards to all public API methods:
  - `getRepository()`
  - `getRepositories()`
  - `listRepos()`
  - `getBranches()`
  - `getReferences()`
  - `getPullrequests()`

## Testing

To verify this fix:
1. Set up Kubero with only Gitea configured (no GitHub PAT)
2. Create a new pipeline with "Enable Pipeline to build from Source"
3. Confirm that GitHub tab is grayed out and not selected by default
4. Connect a Gitea repository
5. Verify no GitHub API calls are made in the logs

Fixes #625