### PR TITLE
fix: correct pod sizes description label

### DIFF
--- a/client/src/components/podsizes/index.vue
+++ b/client/src/components/podsizes/index.vue
@@ -128,7 +128,7 @@
         <v-card-title>{{ $t('podsizes.actions.create') }}</v-card-title>
         <v-card-text>
           <v-text-field v-model="newPodsize.name" :label="$t('podsizes.form.name')"></v-text-field>
-          <v-text-field v-model="newPodsize.description" :label="$t('podsizes.form.name')"></v-text-field>
+          <v-text-field v-model="newPodsize.description" :label="$t('podsizes.form.description')"></v-text-field>
           <v-text-field v-model="newPodsize.resources.requests.cpu" :label="$t('podsizes.form.cpuRequest')"></v-text-field>
           <v-text-field v-model="newPodsize.resources.requests.memory" :label="$t('podsizes.form.memoryRequest')"></v-text-field>
           <v-text-field v-model="newPodsize.resources.limits.cpu" :label="$t('podsizes.form.cpuLimit')"></v-text-field>


### PR DESCRIPTION
# Description

Small UI papercut, no drama: the Pod Sizes create dialog showed two fields labeled `Name`. The second one is actually `newPodsize.description`, so now it uses the existing `Description` label.

No directly related issue found. I checked issues/PRs for podsize / Pod Sizes stuff; #309 and #666 are nearby but not this label bug.

## Repro

1. Open `/podsizes`.
2. Click create.
3. Before: both first fields say `Name`, kinda confusing.
4. After: fields are `Name` and `Description`, as expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran `yarn build` in `client`
- [x] Checked the create dialog label now matches the edit dialog and table column

# Checklist:

- [x] I removed unnecessary debug logs
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
