### PR TITLE
feat(rbac): roles and api guards

### DIFF
--- a/client/src/components/accounts/roles.vue
+++ b/client/src/components/accounts/roles.vue
@@ -136,7 +136,7 @@
           class="ma-2"
           color="secondary"
           @click="openEditRoleDialog(item)"
-          :disabled="item.name === 'admin' || !writeUserPermission"
+          :disabled="isBuiltInRole(item.name) || !writeUserPermission"
         >
           <v-icon color="primary">
             mdi-pencil
@@ -149,7 +149,7 @@
           class="ma-2"
           color="secondary"
           @click="deleteRole(item)"
-          :disabled="item.name === 'admin' || item.name === 'guest' || item.name === 'member' || !writeUserPermission"
+          :disabled="isBuiltInRole(item.name) || !writeUserPermission"
         >
           <v-icon color="primary">
             mdi-delete
@@ -519,6 +519,10 @@ export default defineComponent({
       }
     }
 */
+    const builtInRoleNames = ['admin', 'member', 'developer', 'viewer', 'guest']
+
+    const isBuiltInRole = (name: string) => builtInRoleNames.includes(name)
+
     const getResourcePermissions = (permissions: any, resource: string) => {
       for (const permission of permissions) {
         if (permission.resource === resource) {
@@ -560,6 +564,7 @@ export default defineComponent({
       openCreateDialog,
       saveCreate,
       getResourcePermissions,
+      isBuiltInRole,
       writeUserPermission,
     }
   },

--- a/client/src/locale/en.ts
+++ b/client/src/locale/en.ts
@@ -325,6 +325,13 @@ const messages = {
         name: 'Roles',
         search: 'Search for a Role',
         permission: 'Permission',
+        builtIn: {
+          admin: 'Administrator — full access to apps, pipelines, accounts, and settings',
+          member: 'Member — manage apps and pipelines; read account info',
+          developer: 'Developer — deploy and operate apps; no account or settings access',
+          viewer: 'Viewer — read-only access to apps, pipelines, and logs',
+          guest: 'Guest — legacy read-only role (prefer Viewer for new users)',
+        },
         actions: {
           create: 'Create Role',
           edit: 'Edit Role',

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,49 @@
+# Role-based access control (RBAC)
+
+Kubero uses **roles**, **permissions**, and **teams** to control who can do what in the UI and API.
+
+## Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| **Role** | Named set of permissions (stored in the Kubero database). |
+| **Permission** | `resource:action` pair checked on API routes and in the UI (e.g. `app:write`). |
+| **Team (user group)** | Groups users for **pipeline access** (`spec.access.teams` on a pipeline). Users in the `admin` team see all pipelines. |
+
+Permissions are loaded at login and embedded in the JWT. The API enforces them via `PermissionsGuard`; the Vue UI uses `authStore.hasPermission(...)`.
+
+## Built-in roles
+
+These roles are created on first startup (see `server/src/database/database.service.ts`).
+
+| Role | Intended use | Apps / pipelines | Accounts & settings | Logs / console / reboot | Security scans |
+|------|----------------|------------------|---------------------|-------------------------|----------------|
+| **admin** | Full administrators | write | write (users, config) | yes | write |
+| **member** | Team members with broad access | write | read users; no config write | yes | write |
+| **developer** | Build and operate workloads | write | no account or config access | yes | write |
+| **viewer** | Read-only observers | read | no | logs only (no console/reboot) | read |
+| **guest** | Legacy minimal role (prefer **viewer** for new users) | read | no | no | read |
+
+### Permission actions
+
+- **read** / **write** — used for `app`, `pipeline`, `user`, `config`, `security`.
+- **ok** — used for `console`, `logs`, `reboot`, `token` (and audit read via `read`).
+- **none** — stored in the database but does **not** satisfy API guards (guards require a positive permission such as `app:read`).
+
+## Pipeline scoping (teams)
+
+RBAC roles control *what operations* a user may perform. **Teams** control *which pipelines* they see:
+
+- Assign users to teams under **Accounts → Users**.
+- On each pipeline, set **access teams** (or rely on the `admin` team for global access).
+- The `admin` **user group** bypasses pipeline filters.
+
+## Managing roles
+
+Administrators can review and customize roles under **Accounts → Roles** (requires `user:read` / `user:write`).
+
+Built-in roles (`admin`, `member`, `developer`, `viewer`, `guest`) cannot be deleted from the UI.
+
+## Related issue
+
+This model implements the roles described in [kubero#545](https://github.com/kubero-dev/kubero/issues/545).

--- a/server/src/addons/addons.controller.ts
+++ b/server/src/addons/addons.controller.ts
@@ -7,6 +7,8 @@ import {
 } from '@nestjs/swagger';
 import { OKDTO } from '../common/dto/ok.dto';
 import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
 
 @Controller({ path: 'api/addons', version: '1' })
 export class AddonsController {
@@ -19,7 +21,8 @@ export class AddonsController {
     type: OKDTO,
     isArray: false,
   })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   async getAddons() {
     return this.addonsService.getAddonsList();
@@ -32,7 +35,8 @@ export class AddonsController {
     type: OKDTO,
     isArray: false,
   })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   async getOperators() {
     return this.addonsService.getOperatorsList();

--- a/server/src/database/database.service.ts
+++ b/server/src/database/database.service.ts
@@ -393,6 +393,64 @@ export class DatabaseService {
         Logger.log('Role "guest" seeded successfully.', 'DatabaseService');
       });
 
+    // Developer: deploy and operate apps, no account or cluster settings access
+    await prisma.role
+      .upsert({
+        where: { name: 'developer' },
+        update: {},
+        create: {
+          name: 'developer',
+          description:
+            'Developer role — manage apps and pipelines, logs, console, and builds',
+          permissions: {
+            create: [
+              { action: 'write', resource: 'app' },
+              { action: 'write', resource: 'pipeline' },
+              { action: 'none', resource: 'user' },
+              { action: 'none', resource: 'config' },
+              { action: 'ok', resource: 'console' },
+              { action: 'ok', resource: 'logs' },
+              { action: 'ok', resource: 'reboot' },
+              { action: 'read', resource: 'audit' },
+              { action: 'ok', resource: 'token' },
+              { action: 'write', resource: 'security' },
+            ],
+          },
+        },
+      })
+      .then(() => {
+        Logger.log('Role "developer" seeded successfully.', 'DatabaseService');
+      });
+
+    // Viewer: read-only access to apps, pipelines, metrics, and audit
+    await prisma.role
+      .upsert({
+        where: { name: 'viewer' },
+        update: {},
+        create: {
+          name: 'viewer',
+          description:
+            'Viewer role — read-only access to apps, pipelines, logs, and audit',
+          permissions: {
+            create: [
+              { action: 'read', resource: 'app' },
+              { action: 'read', resource: 'pipeline' },
+              { action: 'none', resource: 'user' },
+              { action: 'none', resource: 'config' },
+              { action: 'none', resource: 'console' },
+              { action: 'ok', resource: 'logs' },
+              { action: 'none', resource: 'reboot' },
+              { action: 'read', resource: 'audit' },
+              { action: 'none', resource: 'token' },
+              { action: 'read', resource: 'security' },
+            ],
+          },
+        },
+      })
+      .then(() => {
+        Logger.log('Role "viewer" seeded successfully.', 'DatabaseService');
+      });
+
     // Ensure the 'everyone' user group exists
     prisma.userGroup
       .upsert({

--- a/server/src/deployments/deployments.controller.ts
+++ b/server/src/deployments/deployments.controller.ts
@@ -21,6 +21,8 @@ import { IUser } from '../auth/auth.interface';
 import { CreateBuild } from './dto/CreateBuild.dto';
 import { OKDTO } from '../common/dto/ok.dto';
 import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
 import { ReadonlyGuard } from '../common/guards/readonly.guard';
 
 @Controller({ path: 'api/deployments', version: '1' })
@@ -28,7 +30,8 @@ export class DeploymentsController {
   constructor(private readonly deploymentsService: DeploymentsService) {}
 
   @Get('/:pipeline/:phase/:app')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
     type: OKDTO,
@@ -49,8 +52,8 @@ export class DeploymentsController {
   }
 
   @Post('/build/:pipeline/:phase/:app')
-  @UseGuards(JwtAuthGuard)
-  @UseGuards(ReadonlyGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('app:write')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
     type: OKDTO,
@@ -91,8 +94,8 @@ export class DeploymentsController {
   }
 
   @Delete('/:pipeline/:phase/:app/:buildName')
-  @UseGuards(JwtAuthGuard)
-  @UseGuards(ReadonlyGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -126,7 +129,8 @@ export class DeploymentsController {
   }
 
   @Get('/:pipeline/:phase/:app/:build/:container/history')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('logs:ok', 'app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -158,8 +162,8 @@ export class DeploymentsController {
   }
 
   @Put('/:pipeline/:phase/:app/:tag')
-  @UseGuards(JwtAuthGuard)
-  @UseGuards(ReadonlyGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',

--- a/server/src/kubernetes/kubernetes.controller.ts
+++ b/server/src/kubernetes/kubernetes.controller.ts
@@ -14,13 +14,16 @@ import {
 } from './dto/kubernetes.dto';
 import { OKDTO } from '../common/dto/ok.dto';
 import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
 
 @Controller({ path: 'api/kubernetes', version: '1' })
 export class KubernetesController {
   constructor(private readonly kubernetesService: KubernetesService) {}
 
   @Get('events')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -41,7 +44,8 @@ export class KubernetesController {
   }
 
   @Get('storageclasses')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -59,7 +63,8 @@ export class KubernetesController {
   }
 
   @Get('domains')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -79,7 +84,8 @@ export class KubernetesController {
   }
 
   @Get('/contexts')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('pipeline:read', 'pipeline:write')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
     type: OKDTO,

--- a/server/src/metrics/metrics.controller.ts
+++ b/server/src/metrics/metrics.controller.ts
@@ -7,6 +7,8 @@ import {
 } from '@nestjs/swagger';
 import { MetricsService } from './metrics.service';
 import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
 import { OKDTO } from '../common/dto/ok.dto';
 
 @Controller({ path: 'api/metrics', version: '1' })
@@ -14,7 +16,8 @@ export class MetricsController {
   constructor(private metricsService: MetricsService) {}
 
   @Get('/resources/:pipeline/:phase/:app')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -34,7 +37,8 @@ export class MetricsController {
   }
 
   @Get('/uptimes/:pipeline/:phase')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -52,7 +56,8 @@ export class MetricsController {
   }
 
   @Get('/timeseries')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -65,7 +70,8 @@ export class MetricsController {
   }
 
   @Get('/timeseries/:type/:pipeline/:phase/:app')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -169,7 +175,8 @@ export class MetricsController {
   }
 
   @Get('/rules/:pipeline/:phase/:app')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',

--- a/server/src/notifications/notifications.controller.ts
+++ b/server/src/notifications/notifications.controller.ts
@@ -9,9 +9,20 @@ import {
   HttpException,
   HttpStatus,
   Logger,
+  UseGuards,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
 import { NotificationsDbService, CreateNotificationDto, UpdateNotificationDto } from './notifications-db.service';
 import { INotificationConfig } from './notifications.interface';
+import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
+import { ReadonlyGuard } from '../common/guards/readonly.guard';
+import { OKDTO } from '../common/dto/ok.dto';
 
 export interface ApiResponse<T = any> {
   success: boolean;
@@ -26,6 +37,11 @@ export class NotificationsController {
   constructor(private readonly notificationsDbService: NotificationsDbService) {}
 
   @Get()
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('config:read', 'config:write')
+  @ApiBearerAuth('bearerAuth')
+  @ApiForbiddenResponse({ description: 'Error: Unauthorized', type: OKDTO })
+  @ApiOperation({ summary: 'List notification configurations' })
   async findAll(): Promise<ApiResponse<INotificationConfig[]>> {
     try {
       const notifications = await this.notificationsDbService.getNotificationConfigs();
@@ -43,6 +59,11 @@ export class NotificationsController {
   }
 
   @Get(':id')
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('config:read', 'config:write')
+  @ApiBearerAuth('bearerAuth')
+  @ApiForbiddenResponse({ description: 'Error: Unauthorized', type: OKDTO })
+  @ApiOperation({ summary: 'Get a notification configuration' })
   async findOne(@Param('id') id: string): Promise<ApiResponse<INotificationConfig>> {
     try {
       const notification = await this.notificationsDbService.findById(id);
@@ -67,6 +88,11 @@ export class NotificationsController {
   }
 
   @Post()
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('config:write')
+  @ApiBearerAuth('bearerAuth')
+  @ApiForbiddenResponse({ description: 'Error: Unauthorized', type: OKDTO })
+  @ApiOperation({ summary: 'Create a notification configuration' })
   async create(@Body() createNotificationDto: CreateNotificationDto): Promise<ApiResponse<INotificationConfig>> {
     try {
       // Validate required fields
@@ -108,6 +134,11 @@ export class NotificationsController {
   }
 
   @Put(':id')
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('config:write')
+  @ApiBearerAuth('bearerAuth')
+  @ApiForbiddenResponse({ description: 'Error: Unauthorized', type: OKDTO })
+  @ApiOperation({ summary: 'Update a notification configuration' })
   async update(
     @Param('id') id: string,
     @Body() updateNotificationDto: Partial<CreateNotificationDto>,
@@ -152,6 +183,11 @@ export class NotificationsController {
   }
 
   @Delete(':id')
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('config:write')
+  @ApiBearerAuth('bearerAuth')
+  @ApiForbiddenResponse({ description: 'Error: Unauthorized', type: OKDTO })
+  @ApiOperation({ summary: 'Delete a notification configuration' })
   async remove(@Param('id') id: string): Promise<ApiResponse> {
     try {
       await this.notificationsDbService.delete(id);

--- a/server/src/repo/repo.controller.ts
+++ b/server/src/repo/repo.controller.ts
@@ -16,6 +16,8 @@ import {
 } from '@nestjs/swagger';
 import { OKDTO } from '../common/dto/ok.dto';
 import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
 import { ReadonlyGuard } from '../common/guards/readonly.guard';
 
 @Controller({ path: 'api/repo', version: '1' })
@@ -23,7 +25,8 @@ export class RepoController {
   constructor(private readonly repoService: RepoService) {}
 
   @Get('/providers')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -36,7 +39,8 @@ export class RepoController {
   }
 
   @Get('/:provider/repositories')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -56,7 +60,8 @@ export class RepoController {
   }
 
   @Get('/:provider/:gitrepob64/branches')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write', 'pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -85,7 +90,8 @@ export class RepoController {
   }
 
   @Get('/:provider/:gitrepob64/pullrequests')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write', 'pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -114,7 +120,8 @@ export class RepoController {
   }
 
   @Get('/:provider/:gitrepob64/references')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write', 'pipeline:read', 'pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -143,8 +150,8 @@ export class RepoController {
   }
 
   @Post('/:provider/connect')
-  @UseGuards(JwtAuthGuard)
-  @UseGuards(ReadonlyGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',
@@ -164,8 +171,8 @@ export class RepoController {
   }
 
   @Post('/:provider/disconnect')
-  @UseGuards(JwtAuthGuard)
-  @UseGuards(ReadonlyGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard, ReadonlyGuard)
+  @Permissions('pipeline:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',

--- a/server/src/templates/templates.controller.ts
+++ b/server/src/templates/templates.controller.ts
@@ -8,6 +8,8 @@ import {
 import { TemplatesService } from './templates.service';
 import { Response } from 'express';
 import { JwtAuthGuard } from '../auth/strategies/jwt.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permissions } from '../auth/permissions.decorator';
 import { OKDTO } from '../common/dto/ok.dto';
 
 @Controller({ path: 'api/templates', version: '1' })
@@ -16,7 +18,8 @@ export class TemplatesController {
   constructor(private readonly templatesService: TemplatesService) {}
 
   @Get('/:templateB64')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @Permissions('app:read', 'app:write')
   @ApiBearerAuth('bearerAuth')
   @ApiForbiddenResponse({
     description: 'Error: Unauthorized',


### PR DESCRIPTION
# Description

> Please include a **summary** of the changes and the related issue. Please also include relevant **motivation** and context. List any **dependencies** that are required for this change.

Kubero already had roles, permissions, and JWT-based checks in parts of the UI and API, but the role model was incomplete and several API routes were not consistently protected. This PR implements the RBAC model described in #545 by adding two new built-in roles and tightening API enforcement.

**Summary of changes:**

- **New built-in roles** seeded on startup: **developer** (manage apps/pipelines, logs/console/reboot; no accounts or settings) and **viewer** (read-only apps/pipelines, logs and audit; no writes, console, or reboot).
- **`docs/rbac.md`** documenting roles, permissions, teams vs. roles, and how enforcement works.
- **UI:** built-in roles (`admin`, `member`, `developer`, `viewer`, `guest`) cannot be deleted from **Accounts → Roles**; English locale hints for built-in roles.
- **API:** `PermissionsGuard` added or extended on controllers that were missing or inconsistently guarded:
  - deployments, repo, kubernetes
  - addons, metrics, templates
  - notifications (previously unauthenticated; now requires JWT + `config:read` / `config:write`)

**Motivation:** Issue #545 calls for clearer, enforceable roles beyond admin/member/guest. Without API guards on all sensitive routes, permission checks in the UI could be bypassed. The notifications API in particular was a gap.

**Dependencies:** None. No operator or CLI changes required.

Fixes #545

## Type of change

> Please delete options that are not relevant.

- [ ] Template (non-breaking change which adds a template)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I've built the image and tested it on a kubernetes cluster
- [x] Local dev testing (server + built client, SQLite, kind cluster with Kubero CRDs)

**Manual test plan (reproducible locally):**

1. Start server (`npm run start:dev` in `server/`), build client (`npm run build` in `client/`).
2. Log in as **admin** → **Accounts → Roles** → confirm **developer** and **viewer** exist; confirm built-in roles cannot be deleted.
3. Create users `devtest` (developer) and `viewtest` (viewer), assign **admin** team for pipeline visibility.
4. **Viewer:** Accounts/Settings hidden in nav; pipeline create disabled; app edit/reboot/console disabled; logs allowed.
5. **Developer:** Accounts/Settings hidden; pipeline/app write actions enabled; console/reboot/logs enabled.
6. **API (Swagger or curl):** as viewer/developer, `GET /api/users` and `GET /api/notifications` return **403**; as admin return **200**.

**Test Configuration**:

- Operator Version: n/a (CRDs only on local kind cluster; not required for RBAC verification)
- Kubernetes Version: v1.35.0 (kind-tools)
- Kubero CLI Version (if applicable): n/a

# Checklist:

- [x] I removed unnecessary debug logs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
<!-- - [ ] New and existing unit tests pass locally with my changes -->
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->

---

**Note for reviewers:** Permissions are embedded in the JWT at login — users must **log out and back in** after a role change to pick up new permissions. Repo webhook routes remain unauthenticated by design (external Git providers).