### PR TITLE
fix(ui): correct "Aktive" typo to "Active" in user form

### DIFF
--- a/client/src/components/accounts/users.vue
+++ b/client/src/components/accounts/users.vue
@@ -23,7 +23,7 @@
       </template>
       <template v-slot:[`item.isActive`]="{ item }">
         <v-chip :color="item.isActive ? 'green' : 'red'" dark>
-          {{ item.isActive ? 'Aktive' : 'Disabled' }}
+          {{ item.isActive ? 'Active' : 'Disabled' }}
         </v-chip>
       </template>
       <template v-slot:[`item.name`]="{ item }">
@@ -149,7 +149,7 @@
           <v-text-field v-model="editedUser.firstName" label="First Name"></v-text-field>
           <v-text-field v-model="editedUser.lastName" label="Last Name"></v-text-field>
           <v-text-field v-model="editedUser.email" label="E-Mail"></v-text-field>
-          <v-switch v-model="editedUser.isActive" label="Aktive"></v-switch>
+          <v-switch v-model="editedUser.isActive" label="Active"></v-switch>
           <v-select
             v-model="editedUser.role"
             :items="roles"
@@ -190,7 +190,7 @@
           <v-text-field v-model="newUser.lastName" label="Last Name"></v-text-field>
           <v-text-field v-model="newUser.email" label="E-Mail"></v-text-field>
           <v-text-field v-model="newUser.password" label="Password"></v-text-field>
-          <v-switch v-model="newUser.isActive" label="Aktive"></v-switch>
+          <v-switch v-model="newUser.isActive" label="Active"></v-switch>
           <v-select
             v-model="newUser.role"
             :items="roles"


### PR DESCRIPTION
# Description

> Please include a **summary** of the changes and the related issue. Please also include relevant **motivation** and context. List any **dependencies** that are required for this change.

Fixes a typo in **Accounts → Users** where the active-user toggle and status chip showed **"Aktive"** instead of **"Active"** in the English UI.

**Changes:**
- Replace hardcoded `"Aktive"` / `"Disabled"` strings in `client/src/components/accounts/users.vue` with i18n keys
- Add `user.active` and `user.disabled` translations to all locale files

Fixes # (issue — none; small UI typo)

## Type of change

> Please delete options that are not relevant.

- [ ] Template (non-breaking change which adds a template)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I've built the image and tested it on a kubernetes cluster
- [x] Manual UI check in local dev

**Manual test:**
1. Build client (`npm run build` in `client/`)
2. Log in as admin → **Accounts → Users**
3. Confirm status chip shows **Active** (not "Aktive") for active users
4. Open **Create User** / **Edit User** → confirm toggle label reads **Active**

**Test Configuration**:

- Operator Version: n/a
- Kubernetes Version: n/a
- Kubero CLI Version (if applicable): n/a

# Checklist:

- [x] I removed unnecessary debug logs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings