### PR TITLE
libredb-studio: refresh the pinned tag to 0.16.1 and fix two template defects

### DIFF
--- a/services/libredb-studio/app.yaml
+++ b/services/libredb-studio/app.yaml
@@ -3,7 +3,7 @@ kind: KuberoApp
 metadata:
     name: libredb-studio
     annotations:
-        kubero.dev/template.architecture: "[]"
+        kubero.dev/template.architecture: '["amd64", "arm64"]'
         kubero.dev/template.description: "Modern, AI-powered open-source SQL IDE. Connect to and query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from your browser, with an optional AI assistant to help write and explain queries."
         kubero.dev/template.icon: "https://raw.githubusercontent.com/libredb/libredb-studio/main/public/logo.svg"
         kubero.dev/template.installation: "On first start LibreDB Studio creates an initial admin account (ADMIN_EMAIL / ADMIN_PASSWORD) and a regular user account (USER_EMAIL / USER_PASSWORD). Set a strong JWT_SECRET (minimum 32 characters). Data is stored in a local SQLite file under /app/data by default, so no external database is required."
@@ -50,4 +50,4 @@ spec:
         containerPort: 3000
         pullPolicy: Always
         repository: ghcr.io/libredb/libredb-studio
-        tag: 0.9.27
+        tag: 0.9.59


### PR DESCRIPTION
## What is this PR about?

Refreshes the LibreDB Studio service from the pinned `0.9.27` to `0.16.1`, the current release, and fixes two defects in the template that are independent of the version.

### 1. The template shipped shared secrets

`ADMIN_PASSWORD`, `USER_PASSWORD` and `JWT_SECRET` carried literal placeholder values that are published in this catalog, so every install that did not edit them ran on credentials anyone can read.

That was already poor practice, but at 0.16.x it became a real exposure: when `STORAGE_ENCRYPTION_KEY` is unset, `JWT_SECRET` is also the key that seals saved connection passwords, connection strings, TLS client keys and SSH keys. A shared value means stored credentials are sealed under a key everyone knows.

All three are now empty. The app generates a strong admin password and a strong JWT secret on first start and prints the admin password to the pod log once. `USER_PASSWORD` is optional and the lower privilege account exists only when the operator sets it. An operator who wants to choose their own values can still fill them in before deploying.

### 2. Login looped on a fresh install

The app runs with `NODE_ENV=production` and marks its auth cookie `Secure` on any non loopback host. Kubero creates the ingress with TLS off by default, so the browser was served over plain HTTP, discarded the cookie, and login bounced back to the sign in page with the correct password and no error.

`AUTH_COOKIE_SECURE=false` is now set, with a note in the installation annotation telling the operator to switch it to true once the app is on HTTPS. This is not a regression from the bump: the behaviour existed at `0.9.27` too, and `0.15.0` was the first release that offered an override.

### Also in this change

- The description annotation named seven engines. It now matches what the image actually ships.
- The installation annotation described the old credential behaviour. It now describes the current one.

## How Has This Been Tested?

The service defaults from `app.yaml` (image, env vars, volume mount, container port) were brought up against `ghcr.io/libredb/libredb-studio:0.16.1`:

- container reached a healthy state, `/api/db/health` answered `{"status":"healthy","service":"libredb-studio"}`
- `/api/storage/config` answered `{"provider":"sqlite","serverMode":true}`
- admin login returned `{"success":true,"role":"admin"}`, a wrong password returned HTTP 401
- with `AUTH_COOKIE_SECURE=false` the login response carries `HttpOnly; SameSite=lax` and no `Secure` flag, which is what makes login work over plain HTTP
- `/app/data` was written on the mounted volume, and after a restart the container returned healthy and login still worked
- `yamllint -c services/.yamllint` reports one pre-existing line length warning and no new issues

`ghcr.io/libredb/libredb-studio:0.16.1` publishes `linux/amd64` and `linux/arm64`, matching the architecture annotation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. Not applicable: there is no test suite for service templates.

## A note on the earlier body

An earlier version of this description said the bump was to `0.9.59` and reported a test run against that image, and gave "ARM users were being filtered out" as the reason for the architecture annotation. Both are wrong and I am correcting them rather than leaving them in the record. The annotation is display only metadata in Kubero, nothing filtered on it, and the test evidence above is from `0.16.1`.
